### PR TITLE
Rename nbde_server_create_keys to nbde_server_rotate_keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Role Variables
 The `nbde_server_provider` variable identifies the provider for `nbde_server` role. We currently support `tang` as an `nbde_server` provider, meaning
 that the `nbde_server` role is currently able to provision/deploy a tang server. Default is `tang`.
 
-### `nbde_server_create_new_keys`
-The `nbde_server_create_new_keys` variable indicates whether we should create new keys to be used when deploying the NBDE server. If set to `yes`, keys
-will be created in case there are no keys. Default is `no`.
+### `nbde_server_rotate_keys`
+The `nbde_server_rotate_keys` variable indicates whether we should rotate existing keys -- if any --, then create new keys. If set to
+`yes`, existing keys will be rotate and new keys will be created. Default is `no`.
 
 ### `nbde_server_deploy_keys`
 The `nbde_server_deploy_new_keys` variable indicates whether we should deploy the specific keys located in `nbde_server_keys_dir` directory. Default is `no`.

--- a/README.md
+++ b/README.md
@@ -1,30 +1,20 @@
 Linux `nbde_server` role
 ======================
 
-This role allows users to deploy an NBDE server.
-NBDE stands for Network-Bound Disk Encryption.
+This role allows users to deploy an NBDE server. NBDE stands for Network-Bound Disk Encryption.
 
 The current supported provider is `tang`.
 
 Role Variables
 --------------
 
-### `nbde_server_provider`
-The `nbde_server_provider` variable identifies the provider for `nbde_server` role. We currently support `tang` as an `nbde_server` provider, meaning
-that the `nbde_server` role is currently able to provision/deploy a tang server. Default is `tang`.
-
-### `nbde_server_rotate_keys`
-The `nbde_server_rotate_keys` variable indicates whether we should rotate existing keys -- if any --, then create new keys. If set to
-`yes`, existing keys will be rotate and new keys will be created. Default is `no`.
-
-### `nbde_server_deploy_keys`
-The `nbde_server_deploy_new_keys` variable indicates whether we should deploy the specific keys located in `nbde_server_keys_dir` directory. Default is `no`.
-
-### `nbde_server_fetch_keys`
-The `nbde_server_fetch_keys` variable indicates whether we should fetch keys to the control node, in `nbde_server_keys_dir`. Default is `no`.
-
-### `nbde_server_keys_dir`
-The `nbde_server_keys_dir` variable specifies a directory in the control node that either contains a set of keys to be deployed to the NBDE servers or keys lifted from the NBDE servers. Either `nbde_server_deploy_new_keys` or `nbde_server_fetch_keys` must be set to `yes` for this variable to have any effect. When deploying keys from this directory, the keys should be in the top level dir. This directory *must* exist. Default is `"keys"`.
+| **Variable** | **Default** | **Description** |
+|----------|-------------|------|
+| `nbde_server_provider` | tang | identifies the provider for `nbde_server` role. We currently support `tang` as an `nbde_server` provider, meaning that the `nbde_server` role is currently able to provision/deploy a tang server
+| `nbde_server_rotate_keys`| no | indicates whether we should rotate existing keys -- if any -- , then create new keys. Default behavior (`no`) is to create new keys, if there are none, and don't touch the keys, if they exist. If set to `yes`, existing keys will be rotated and new keys will be created
+|`nbde_server_deploy_keys`| no |indicates whether we should deploy the specific keys located in `nbde_server_keys_dir` directory
+|`nbde_server_fetch_keys`| no | indicates whether we should fetch keys to the control node, in which case they will be placed in `nbde_server_keys_dir`
+|`nbde_server_keys_dir`|`"./keys"`| specifies a directory in the control node that either contains a set of keys to be deployed to the NBDE servers or keys lifted from the NBDE servers. Either `nbde_server_deploy_keys` or `nbde_server_fetch_keys` must be set to `yes` for this variable to have any effect. When deploying keys from this directory, the keys should be in the top level dir. This directory **must** exist
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@
 nbde_server_provider: "tang"
 nbde_server_deploy_keys: no
 nbde_server_fetch_keys: no
-nbde_server_create_new_keys: no
+nbde_server_rotate_keys: no
 nbde_server_keys_dir: "keys"
 
 # vim:set ts=2 sw=2 et:

--- a/library/nbde_server_tang.py
+++ b/library/nbde_server_tang.py
@@ -191,6 +191,10 @@ def run_module():
 
     if state == "keys-created":
         result = create_keys(module, keygen, keydir, force)
+    elif state == "keys-rotated":
+        # We will rotate existing keys and then create new keys.
+        rotate_keys(module, keydir, None)
+        result = create_keys(module, keygen, keydir, force)
     elif state == "keys-deployed":
         result = deploy_keys(module, keydir, base_keysdir, keys_to_deploy_dir)
 

--- a/playbooks/03-create-new-keys-and-fetch-them.yml
+++ b/playbooks/03-create-new-keys-and-fetch-them.yml
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: MIT
 ---
-- name: Ensure NBDE server is deployed and creates new keys
+- name: Create a new set of keys and fetch them
   hosts: nbde_servers_test
   become: true
 
+
   roles:
     - role: nbde_server
-      nbde_server_create_new_keys: yes
+      nbde_server_fetch_keys: yes
+      nbde_server_keys_dir: "my-keys"
 
 # vim:set ts=2 sw=2 et:

--- a/playbooks/06-nbde-server-create-new-keys-and-deploy-them.yml
+++ b/playbooks/06-nbde-server-create-new-keys-and-deploy-them.yml
@@ -7,7 +7,6 @@
 
   roles:
     - role: nbde_server
-      nbde_server_create_new_keys: yes
       nbde_server_deploy_keys: yes
       nbde_server_keys_dir: "keys-to-deploy"
 

--- a/tasks/main-tang.yml
+++ b/tasks/main-tang.yml
@@ -21,17 +21,16 @@
     state: stopped
 
 
-- name: Ensure we have keys
-  when: nbde_server_create_new_keys and not nbde_server_deploy_keys
+- name: Ensure keys are rotated
+  when: nbde_server_rotate_keys
   nbde_server_tang:
-    state: keys-created
+    state: keys-rotated
     keygen: "{{ __nbde_server_keygen }}"
     keydir: "{{ __nbde_server_keydir }}"
 
 
-- name: Ensure we have keys for deploying
-  when: nbde_server_create_new_keys and nbde_server_deploy_keys
-  run_once: yes
+- name: Ensure we have keys
+  when: not nbde_server_rotate_keys
   nbde_server_tang:
     state: keys-created
     keygen: "{{ __nbde_server_keygen }}"
@@ -50,7 +49,7 @@
 
 
 - name: Ensure we fetch the created keys for deploying
-  when: nbde_server_create_new_keys and nbde_server_deploy_keys
+  when: nbde_server_deploy_keys
   run_once: yes
   synchronize:
     mode: pull

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -5,4 +5,7 @@
   roles:
     - nbde_server
 
+  tasks:
+    - include_tasks: verify-role-results.yml
+
 # vim:set ts=2 sw=2 et:

--- a/tests/tests_default_vars.yml
+++ b/tests/tests_default_vars.yml
@@ -6,15 +6,13 @@
     - block:
         - import_role:
             name: nbde_server
-          when: false
-
         - assert:
-            that: "vars[item] is defined"
+            that: "{{ item }} is defined"
           loop:
             - nbde_server_provider
             - nbde_server_deploy_keys
             - nbde_server_fetch_keys
-            - nbde_server_create_new_keys
+            - nbde_server_rotate_keys
             - nbde_server_keys_dir
           when: "ansible_version.full is version_compare('2.7', '>=')"
 # vim:set ts=2 sw=2 et:

--- a/tests/tests_nbde_server_rotate_keys.yml
+++ b/tests/tests_nbde_server_rotate_keys.yml
@@ -1,0 +1,67 @@
+---
+# Expected behavior of nbde_server_rotate_keys is the following:
+# - if there are no keys, create new keys
+# - if there are keys, do not touch them, unless set
+# - if set, rotate existing keys, if any, plus create new keys
+- name: Verify behavior of nbde_server_rotate_keys
+  hosts: all
+
+  tasks:
+    - name: Ensure we have keys
+      import_role:
+        name: nbde_server
+
+    - name: Gather keys
+      find:
+        paths: "{{ __nbde_server_keydir }}"
+        file_type: file
+        recurse: no
+        patterns:
+          - '*.jwk'
+          - '.*.jwk'
+      check_mode: yes
+      register: existing_keys
+
+    - name: Run with nbde_server_rotate_keys not set to check keys
+      import_role:
+        name: nbde_server
+      vars:
+        nbde_server_rotate_keys: false
+
+    - name: Gather keys after running with nbde_server_rotate_keys not set
+      find:
+        paths: "{{ __nbde_server_keydir }}"
+        file_type: file
+        recurse: no
+        patterns:
+          - '*.jwk'
+          - '.*.jwk'
+      check_mode: yes
+      register: existing_keys_rotate_not_set
+
+    - name: Check whether keys changed - nbde_server_rotate_keys not set
+      assert:
+        that: "{{ existing_keys.files == existing_keys_rotate_not_set.files }}"
+
+    - name: Run with nbde_server_rotate_keys set to check keys
+      import_role:
+        name: nbde_server
+      vars:
+        nbde_server_rotate_keys: true
+
+    - name: Gather keys after running with nbde_server_rotate_keys set
+      find:
+        paths: "{{ __nbde_server_keydir }}"
+        file_type: file
+        recurse: no
+        patterns:
+          - '*.jwk'
+          - '.*.jwk'
+      check_mode: yes
+      register: existing_keys_rotate_set
+
+    - name: Check whether keys changed - nbde_server_rotate_keys set
+      assert:
+        that: "{{ existing_keys.files != existing_keys_rotate_set.files }}"
+
+# vim:set ts=2 sw=2 et:

--- a/tests/tests_nbde_server_rotate_keys.yml
+++ b/tests/tests_nbde_server_rotate_keys.yml
@@ -41,7 +41,7 @@
 
     - name: Check whether keys changed - nbde_server_rotate_keys not set
       assert:
-        that: "{{ existing_keys.files == existing_keys_rotate_not_set.files }}"
+        that: existing_keys.files == existing_keys_rotate_not_set.files
 
     - name: Run with nbde_server_rotate_keys set to check keys
       import_role:
@@ -62,6 +62,6 @@
 
     - name: Check whether keys changed - nbde_server_rotate_keys set
       assert:
-        that: "{{ existing_keys.files != existing_keys_rotate_set.files }}"
+        that: existing_keys.files != existing_keys_rotate_set.files
 
 # vim:set ts=2 sw=2 et:

--- a/tests/verify-role-results.yml
+++ b/tests/verify-role-results.yml
@@ -8,7 +8,7 @@
 
 - name: Check whether required packages are installed
   assert:
-    that: "{{ not packages_installed.changed }}"
+    that: not packages_installed.changed
 
 - name: Gather state of service when it should be enabled and started
   when: state is not defined or state != "stopped"
@@ -22,7 +22,7 @@
 - name: Check whether service is enabled and started when it should be
   when: state is not defined or state != "stopped"
   assert:
-    that: "{{ not nbde_service_started.changed }}"
+    that: not nbde_service_started.changed
 
 - name: Gather state of service when it should be enabled and stopped
   when: state is defined or state == "stopped"
@@ -36,7 +36,7 @@
 - name: Check whether service is enabled and stopped when it should be
   when: state is defined or state == "stopped"
   assert:
-    that: "{{ not nbde_service_stopped.changed }}"
+    that: not nbde_service_stopped.changed
 
 - name: Include the appropriate provider verification tasks
   include_tasks: "verify-{{ nbde_server_provider }}-results.yml"

--- a/tests/verify-role-results.yml
+++ b/tests/verify-role-results.yml
@@ -1,0 +1,44 @@
+---
+- name: Gather state of required packages
+  package:
+    name: "{{ __nbde_server_package_list }}"
+    state: present
+  check_mode: true
+  register: packages_installed
+
+- name: Check whether required packages are installed
+  assert:
+    that: "{{ not packages_installed.changed }}"
+
+- name: Gather state of service when it should be enabled and started
+  when: state is not defined or state != "stopped"
+  service:
+    name: "{{ __nbde_server_service }}"
+    enabled: true
+    state: started
+  check_mode: true
+  register: nbde_service_started
+
+- name: Check whether service is enabled and started when it should be
+  when: state is not defined or state != "stopped"
+  assert:
+    that: "{{ not nbde_service_started.changed }}"
+
+- name: Gather state of service when it should be enabled and stopped
+  when: state is defined or state == "stopped"
+  service:
+    name: "{{ __nbde_server_service }}"
+    enabled: true
+    state: stopped
+  check_mode: true
+  register: nbde_service_stopped
+
+- name: Check whether service is enabled and stopped when it should be
+  when: state is defined or state == "stopped"
+  assert:
+    that: "{{ not nbde_service_stopped.changed }}"
+
+- name: Include the appropriate provider verification tasks
+  include_tasks: "verify-{{ nbde_server_provider }}-results.yml"
+
+# vim:set ts=2 sw=2 et:

--- a/tests/verify-tang-results.yml
+++ b/tests/verify-tang-results.yml
@@ -1,0 +1,14 @@
+---
+- name: Gather state of keys
+  nbde_server_tang:
+    state: keys-created
+    keygen: "{{ __nbde_server_keygen }}"
+    keydir: "{{ __nbde_server_keydir }}"
+  check_mode: true
+  register: existing_keys
+
+- name: Check whether there are keys
+  assert:
+    that: "{{ not existing_keys.changed }}"
+
+# vim:set ts=2 sw=2 et:

--- a/tests/verify-tang-results.yml
+++ b/tests/verify-tang-results.yml
@@ -9,6 +9,6 @@
 
 - name: Check whether there are keys
   assert:
-    that: "{{ not existing_keys.changed }}"
+    that: not existing_keys.changed
 
 # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
The behavior is the following:

    - if there are no keys, create them
    - if there are keys, do not touch them, unless nbde_server_create_keys is
      set to `yes', in which case the keys will be rotated and new keys will
      be created