### PR TITLE
fix asciidoc conversion issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ To redeploy keys, they must be placed into subdirectories named after the host t
     - linux-system-roles.nbde_server
 ```
 
-#### Example 4: deploy an NBDE server and use the same keys in every host (this is not recommended, but it is supported)
+#### Example 4: deploy an NBDE server and use the same keys in every host
+**NOTE** This is not recommended, but it is supported
 ```yaml
 ---
 - hosts: all


### PR DESCRIPTION
The error looks like this:
```
[blockdef-pass] missing closing delimiter
```
The line marked with `####` was too long.  Moved the note to
a separate line.