### PR TITLE
Specify path for looking up variables

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,11 +5,13 @@
 - name: Set version-specific variables
   include_vars: "{{ item }}"
   with_first_found:
-    - "{{ ansible_distribution }}-{{ ansible_distribution_version }}.yml"
-    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
-    - "{{ ansible_distribution }}.yml"
-    - "{{ ansible_os_family }}.yml"
-    - "default.yml"
+    - files:
+        - "{{ ansible_distribution }}-{{ ansible_distribution_version }}.yml"
+        - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"  # yamllint disable-line rule:line-length
+        - "{{ ansible_distribution }}.yml"
+        - "{{ ansible_os_family }}.yml"
+        - "default.yml"
+      paths: "{{ role_path }}/vars"
 
 - name: Include the appropriate provider tasks
   include_tasks: "main-{{ nbde_server_provider }}.yml"


### PR DESCRIPTION
So that we load the files from the correct place, when the role gets
included in another role.

When this role gets included from a different role, the task checking
out the system to load specific variables for the system may end up
looking in other places and loading a wrong file.

For instance, the nbde_client role includes this one for the testing,
and since it detects the system is e.g. Fedora, it will try to load
Fedora.yml in this role's vars/; however, since it does not exist and
does exist a Fedora.yml somewhere in nbde_client's, it will load that
file instead, which causes problems since the expected variables will
not be set -- in this case, we should load defaults.yml from
nbde_server's vars/.