### PR TITLE
RHELPLAN-46757 - bug with current implementation of platform/version …

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,16 +2,18 @@
 ---
 # tasks file for nbde_server.
 
-- name: Set version-specific variables
-  include_vars: "{{ item }}"
-  with_first_found:
-    - files:
-        - "{{ ansible_distribution }}-{{ ansible_distribution_version }}.yml"
-        - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"  # yamllint disable-line rule:line-length
-        - "{{ ansible_distribution }}.yml"
-        - "{{ ansible_os_family }}.yml"
+- name: Set version specific variables
+  include_vars: "{{ lookup('first_found', ffparams) }}"
+  vars:
+    ffparams:
+      files:
+        - "{{ ansible_facts['distribution'] }}_{{ ansible_facts['distribution_version'] }}.yml"
+        - "{{ ansible_facts['distribution'] }}_{{ ansible_facts['distribution_major_version'] }}.yml"  # yamllint disable-line rule:line-length
+        - "{{ ansible_facts['distribution'] }}.yml"
+        - "{{ ansible_facts['os_family'] }}.yml"
         - "default.yml"
-      paths: "{{ role_path }}/vars"
+      paths:
+        - "{{ role_path }}/vars"
 
 - name: Include the appropriate provider tasks
   include_tasks: "main-{{ nbde_server_provider }}.yml"


### PR DESCRIPTION
…specific vars/tasks file include/import

Updated based on https://github.com/oasis-roles/meta_standards
- Using loop instead of with_first_found.
- Using '_' instead of '-' in the platform/version specific file name.