### PR TITLE
Introduce nbde_server_manage_firewall and nbde_server_manage_selinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ These are the variables that can be passed to the role:
 |`nbde_server_fetch_keys`| `no` | indicates whether we should fetch keys to the control node, in which case they will be placed in `nbde_server_keys_dir`. You **must** set `nbde_server_keys_dir` to use `nbde_server_fetch_keys`.
 |`nbde_server_deploy_keys`| `no` |indicates whether we should deploy the keys located in `nbde_server_keys_dir` directory to the remote hosts. You **must** set `nbde_server_keys_dir` to use `nbde_server_deploy_keys`.
 |`nbde_server_keys_dir`| | specifies a directory in the control node that contains keys to be deployed to the remote hosts. Keys located in the top level directory will be deployed to every remote host, while keys located within subdirectories named after the remote hosts  -- as per the inventory -- will be deployed only to these specific hosts. `nbde_server_keys_dir` **must** be an absolute path. You need to set this to use either `nbde_server_fetch_keys` and/or `nbde_server_deploy_keys`.
-|`nbde_server_port`|`80`| setup custom port which will be enabled in SELinux and firewalld.
-|`nbde_server_firewall_zone`|`public`| change the default zone where the port should be opened.
+|`nbde_server_manage_firewall`| `no` | manage the nbde server port and zone using the `firewall` role if set to `yes`.
+|`nbde_server_manage_selinux`| `no` | manage the nbde server port using the `selinux` role if set to `yes`.
+|`nbde_server_port`| `80` | setup custom port which will be enabled in SELinux and firewalld. You **must** set `nbde_server_manage_selinux` and `nbde_server_manage_firewall` to `yes` to enable the port, respectively.
+|`nbde_server_firewall_zone`| `public` | change the default zone where the port should be opened. You **must** set `nbde_server_manage_firewall` to `yes` to change the default zone.
 
 
 
@@ -121,6 +123,8 @@ To redeploy keys, they must be placed into subdirectories named after the host t
 - hosts: all
 
   vars:
+    nbde_server_manage_firewall: yes
+    nbde_server_manage_selinux: yes
     nbde_server_port: 7500
     nbde_server_firewall_zone: dmz
   roles:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,4 +44,10 @@ nbde_server_port: 80
 # can change that here. Usually it should be left like that.
 nbde_server_firewall_zone: public
 
+# If true, manage the nbde server port using the firewall role.
+nbde_server_manage_firewall: false
+
+# If true, manage the nbde server port using the selinux role.
+nbde_server_manage_selinux: false
+
 # vim:set ts=2 sw=2 et:

--- a/tasks/tangd-custom-port.yml
+++ b/tasks/tangd-custom-port.yml
@@ -10,6 +10,8 @@
         proto: tcp
         setype: tangd_port_t
         state: present
+  when:
+    - nbde_server_manage_selinux | bool
 
 # This block creates the override file for systemd with the new
 # port that we have requested
@@ -49,3 +51,5 @@
         state: enabled
         immediate: true
         permanent: true
+  when:
+    - nbde_server_manage_firewall | bool

--- a/tests/tests_tangd_custom_port.yml
+++ b/tests/tests_tangd_custom_port.yml
@@ -4,6 +4,8 @@
   vars:
     nbde_server_port: 7500
     nbde_server_firewall_zone: public
+    nbde_server_manage_firewall: yes
+    nbde_server_manage_selinux: yes
   tasks:
     - name: install with custom port and firewall zone
       import_role:


### PR DESCRIPTION
Introduce nbde_server_manage_firewall and nbde_server_manage_selinux to manage the custom ports implemented in "Add support for custom ports (#38)"

- If nbde_server_manage_firewall is set to true, use the firewall role to manage the nbde server port.
- If nbde_server_manage_selinux is set to true, use the selinux role to manage the nbde server port.

Note: this pr adds the two variables to manage the functionality, which is already implemented in "Add support for custom ports (#38)". These variables are added to provide the same api across the roles.