### PR TITLE
Use tox-lsr 2.14.1; use py39 for ansible related checks; use podman instead of docker

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -4,7 +4,7 @@ on:  # yamllint disable-line rule:truthy
   - pull_request
   - push
 env:
-  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.13.0"
+  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.14.1"
   LSR_ANSIBLE_TEST_DOCKER: "true"
   LSR_ANSIBLES: 'ansible==2.9.*'
   LSR_MSCENARIOS: default
@@ -43,6 +43,10 @@ jobs:
           sudo apt-get install -y git
           pip install "$TOX_LSR"
           lsr_ci_preinstall
+          if [ "${{ matrix.pyver_os.os }}" = ubuntu-latest ]; then
+              sudo apt-get purge -y moby-cli
+              sudo apt-get install -y podman-docker
+          fi
       - name: Run tox tests
         run: |
           set -euxo pipefail
@@ -51,9 +55,9 @@ jobs:
           case "$toxpyver" in
           27) toxenvs="${toxenvs},coveralls,flake8,pylint" ;;
           36) toxenvs="${toxenvs},coveralls,black,yamllint,shellcheck" ;;
-          38) toxenvs="${toxenvs},coveralls,ansible-lint,ansible-plugin-scan,collection,ansible-test" ;;
-          39) toxenvs="${toxenvs},coveralls,ansible-managed-var-comment" ;;
-          310) toxenvs="${toxenvs},coveralls,custom,check-meta-versions" ;;
-          311) toxenvs="${toxenvs},coveralls,custom" ;;
+          38) toxenvs="${toxenvs},coveralls" ;;
+          39) toxenvs="${toxenvs},coveralls,ansible-lint,ansible-managed-var-comment,ansible-plugin-scan,collection,ansible-test" ;;
+          310) toxenvs="${toxenvs},coveralls,check-meta-versions" ;;
+          311) toxenvs="${toxenvs},coveralls" ;;
           esac
           TOXENV="$toxenvs" lsr_ci_runtox


### PR DESCRIPTION
CI is broken pretty hard right now due to tox 4.x and ansible-test
images.
It will take non-trivial effort to make tox-lsr work with tox 4.x. So,
in the meantime:

* tox-lsr 2.14.1 forces the use of tox 3.x
* tox-lsr 2.14.0 moved to use ansible-core 2.14 which does not support
  python 3.8 - rather than try to revert that, I moved some of the
  ansible related checks to use python 3.9
* for some reason the latest ansible-test image does not work with
  docker - so install the podman-docker package to "fool" the system
  into using podman instead of docker - the package is only available on
  ubuntu-latest - in order to do this, we first have to remove moby-cli
  (aka docker-client)

This isn't pretty, and I have a big plan to replace all of this stuff with

* individual github actions for yamllint, ansible-lint, ansible-test, etc.
* removal of py, pylint, etc. tests for non-python roles

We need CI to be working right now, so please bear with me as we try to
get this working again, and fix it the "right way" soon.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
