### PR TITLE
ansible-lint 6.x fixes

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,21 @@
 ---
+profile: production
 skip_list:
   - fqcn-builtins
+exclude_paths:
+  - tests/roles/
+  - .github/
+  - examples/roles/
+kinds:
+  - yaml: "**/meta/collection-requirements.yml"
+  - yaml: "**/tests/collection-requirements.yml"
+  - playbook: "**/tests/tests_*.yml"
+  - playbook: "**/tests/setup-snapshot.yml"
+  - tasks: "**/tests/*.yml"
+  - playbook: "**/tests/playbooks/*.yml"
+  - tasks: "**/tests/tasks/*.yml"
+  - tasks: "**/tests/tasks/*/*.yml"
+  - vars: "**/tests/vars/*.yml"
+  - playbook: "**/examples/*.yml"
+mock_roles:
+  - linux-system-roles.nbde_server

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,15 +1,5 @@
 # SPDX-License-Identifier: MIT
 ---
-extends: .yamllint_defaults.yml
-# possible customizations over the base yamllint config
-# skip the yaml files in the /tests/ directory
-# NOTE: If you want to customize `ignore` you'll have to
-# copy in all of the config from .yamllint.yml, then
-# add your own - so if you want to just add /tests/ to
-# be ignored, you'll have to add the ignores from the base
-# ignore: |
-#   /tests/
-#   /.tox/
-# skip checking line length
-# NOTE: the above does not apply to `rules` - you do not
-# have to copy all of the rules from the base config
+ignore: |
+  /.tox/
+extends: default

--- a/.yamllint_defaults.yml
+++ b/.yamllint_defaults.yml
@@ -1,7 +1,0 @@
-# SPDX-License-Identifier: MIT
----
-ignore: |
-  /.tox/
-extends: default
-rules:
-  document-start: disable

--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ To use either of these options, you need to specify `nbde_server_keys_dir`, a di
 
 The behavior of using these variables is described next:
 
-#####  When `nbde_server_fetch_keys` is set to `yes`, the role will fetch keys from the hosts in the following manner:
+#####  When `nbde_server_fetch_keys` is set to `true`, the role will fetch keys from the hosts in the following manner:
 - if `nbde_server_deploy_keys` is not set, the keys from every host will be fetched and placed in directories named after the host,
   inside `nbde_server_keys_dir`
 - if `nbde_server_deploy_keys` is set, only the keys from the first host in the inventory will be fetched, and it will be placed in
   the top level directory of `nbde_server_keys_dir`
 
 
-#####  `nbde_server_deploy_keys` is simple: if it is set to yes, it will deploy the keys available in `nbde_server_keys_dir`, in the following manner:
+#####  `nbde_server_deploy_keys` is simple: if it is set to true, it will deploy the keys available in `nbde_server_keys_dir`, in the following manner:
 - the keys located in the top level directory of `nbde_server_keys_dir` will be deployed to every host
 - the keys located within subdirectories named after hosts in the inventory, inside `nbde_server_keys_dir`, will be deployed to that
   specific host

--- a/examples/deploy_and_reuse_keys.yml
+++ b/examples/deploy_and_reuse_keys.yml
@@ -2,13 +2,12 @@
 # This playbook will deploy an NBDE server and then use its keys for
 # deploying the other servers. Sharing keys is not recommended, but this
 # is supported.
-- hosts: all
-
+- name: Deploy and reuse keys
+  hosts: all
   vars:
     nbde_server_fetch_keys: true
     nbde_server_deploy_keys: true
     nbde_server_keys_dir: /root/nbde_server/keys
-
   roles:
     - linux-system-roles.nbde_server
 # vim:set ts=2 sw=2 et:

--- a/examples/lift_keys_from_servers.yml
+++ b/examples/lift_keys_from_servers.yml
@@ -1,10 +1,9 @@
 ---
-- hosts: all
-
+- name: Lift keys from server
+  hosts: all
   vars:
     nbde_server_fetch_keys: true
     nbde_server_keys_dir: /root/nbde_server/keys
-
   roles:
     - linux-system-roles.nbde_server
 # vim:set ts=2 sw=2 et:

--- a/examples/redeploy_keys.yml
+++ b/examples/redeploy_keys.yml
@@ -4,12 +4,11 @@
 # does that, so you can run this playbook after running that other
 # example, to see how it works. Make sure both playbooks use the same
 # nbde_server_keys_dir.
-- hosts: all
-
+- name: Redeploy keys
+  hosts: all
   vars:
     nbde_server_deploy_keys: true
     nbde_server_keys_dir: /root/nbde_server/keys
-
   roles:
     - linux-system-roles.nbde_server
 # vim:set ts=2 sw=2 et:

--- a/examples/simple_deploy.yml
+++ b/examples/simple_deploy.yml
@@ -1,6 +1,6 @@
 ---
-- hosts: all
-
+- name: Simple deployment
+  hosts: all
   roles:
     - linux-system-roles.nbde_server
 # vim:set ts=2 sw=2 et:

--- a/tests/setup-snapshot.yml
+++ b/tests/setup-snapshot.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Setup snapshot
+  hosts: all
   tasks:
     - name: Set platform/version specific variables
       include_role:

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -4,8 +4,8 @@
   gather_facts: false
   roles:
     - linux-system-roles.nbde_server
-
   tasks:
-    - include_tasks: tasks/verify-role-results.yml
+    - name: Verify role results
+      include_tasks: tasks/verify-role-results.yml
 
 # vim:set ts=2 sw=2 et:

--- a/tests/tests_default_vars.yml
+++ b/tests/tests_default_vars.yml
@@ -1,10 +1,11 @@
 ---
 - name: Ensure that the role declares all parameters in defaults
   hosts: all
-
   tasks:
-    - block:
-        - import_role:
+    - name: Run test
+      block:
+        - name: Import role
+          import_role:
             name: linux-system-roles.nbde_server
         - name: Assert that the role declares all parameters in defaults
           assert:

--- a/tests/tests_include_vars_from_parent.yml
+++ b/tests/tests_include_vars_from_parent.yml
@@ -1,8 +1,9 @@
 ---
-- hosts: all
+- name: Test role variable override
+  hosts: all
   gather_facts: true
   tasks:
-    - name: create var file in caller that can override the one in called role
+    - name: Create var file in caller that can override the one in called role
       delegate_to: localhost
       copy:
         # usually the fake file will cause the called role to crash of
@@ -38,7 +39,8 @@
           map('join') | product(versions) | map('join') | list +
           [facts['distribution'], facts['os_family']] }}"
 
-    - import_role:
+    - name: Import role
+      import_role:
         name: caller
       vars:
         roletoinclude: linux-system-roles.nbde_server

--- a/tests/tests_nbde_server_keys_dir.yml
+++ b/tests/tests_nbde_server_keys_dir.yml
@@ -14,7 +14,7 @@
           vars:
             nbde_server_fetch_keys: true
 
-        - name: unreachable task
+        - name: Unreachable task
           fail:
             msg: UNREACH
 
@@ -31,7 +31,7 @@
           vars:
             nbde_server_deploy_keys: true
 
-        - name: unreachable task
+        - name: Unreachable task
           fail:
             msg: UNREACH
 
@@ -49,7 +49,7 @@
             nbde_server_fetch_keys: true
             nbde_server_deploy_keys: true
 
-        - name: unreachable task
+        - name: Unreachable task
           fail:
             msg: UNREACH
 
@@ -67,7 +67,7 @@
             nbde_server_fetch_keys: true
             nbde_server_keys_dir: ./foobar
 
-        - name: unreachable task
+        - name: Unreachable task
           fail:
             msg: UNREACH
 
@@ -85,7 +85,7 @@
             nbde_server_fetch_keys: true
             nbde_server_keys_dir: foobar
 
-        - name: unreachable task
+        - name: Unreachable task
           fail:
             msg: UNREACH
 

--- a/tests/tests_nbde_server_service_state.yml
+++ b/tests/tests_nbde_server_service_state.yml
@@ -7,7 +7,7 @@
   hosts: all
 
   tasks:
-    - name: not accepting connections specifying state stopped
+    - name: Not accepting connections specifying state stopped
       import_role:
         name: linux-system-roles.nbde_server
       vars:
@@ -27,7 +27,7 @@
         that: "{{ not item.changed }}"
       loop: "{{ nbde_server_state.results }}"
 
-    - name: accepting connections without specifying state
+    - name: Accepting connections without specifying state
       import_role:
         name: linux-system-roles.nbde_server
 
@@ -45,7 +45,7 @@
         that: "{{ not item.changed }}"
       loop: "{{ nbde_server_state.results }}"
 
-    - name: accepting connections specifying state started
+    - name: Accepting connections specifying state started
       import_role:
         name: linux-system-roles.nbde_server
       vars:

--- a/tests/tests_tangd_custom_port.yml
+++ b/tests/tests_tangd_custom_port.yml
@@ -7,11 +7,11 @@
     nbde_server_manage_firewall: true
     nbde_server_manage_selinux: true
   tasks:
-    - name: install with custom port and firewall zone
+    - name: Install with custom port and firewall zone
       include_role:
         name: linux-system-roles.nbde_server
 
-    - name: check if port is open
+    - name: Check if port is open
       shell:
         cmd: |-
           set -euo pipefail
@@ -21,7 +21,7 @@
         search(':' ~ (nbde_server_port | string) ~ '$')
       changed_when: false
 
-    - name: check if port TCP is open
+    - name: Check if port TCP is open
       shell:
         cmd: |-
           set -euo pipefail
@@ -30,14 +30,14 @@
       failed_when: __open_ports_output.stdout != "tcp"
       changed_when: false
 
-    - name: check if port is opened in firewall
+    - name: Check if port is opened in firewall
       command: >-
         firewall-cmd --zone {{ nbde_server_firewall_zone }} --query-port
         {{ nbde_server_port }}/tcp
       register: __firewall_output
       changed_when: false
 
-    - name: check if firewall zone is set
+    - name: Check if firewall zone is set
       shell:
         cmd: |-
           set -euo pipefail
@@ -48,7 +48,7 @@
         __firewall_output_zone.stdout != "{{ nbde_server_firewall_zone }}"
       changed_when: false
 
-    - name: install with default port and firewall zone
+    - name: Install with default port and firewall zone
       include_role:
         name: linux-system-roles.nbde_server
       vars:
@@ -57,7 +57,7 @@
         nbde_server_manage_firewall: true
         nbde_server_manage_selinux: true
 
-    - name: check if port is open
+    - name: Check if port is open
       shell:
         cmd: |-
           set -euo pipefail
@@ -67,7 +67,7 @@
         search(':80$')
       changed_when: false
 
-    - name: check if port TCP is open
+    - name: Check if port TCP is open
       shell:
         cmd: |-
           set -euo pipefail
@@ -76,14 +76,14 @@
       failed_when: __open_ports_output.stdout != "tcp"
       changed_when: false
 
-    - name: check if port is opened in firewall
+    - name: Check if port is opened in firewall
       command: >-
         firewall-cmd --zone {{ nbde_server_firewall_zone }} --query-port
         80/tcp
       register: __firewall_output
       changed_when: false
 
-    - name: check if firewall zone is set
+    - name: Check if firewall zone is set
       shell:
         cmd: |-
           set -euo pipefail


### PR DESCRIPTION
All tasks must be named
Tasks names must begin with uppercase letter
Use `true`/`false` instead of `yes`/`no`
other changes
