### PR TITLE
fix some more Jinja constructs

### DIFF
--- a/tests/tasks/verify-role-results.yml
+++ b/tests/tasks/verify-role-results.yml
@@ -21,7 +21,7 @@
 
 - name: Check services are enabled and started
   assert:
-    that: "{{ not item.changed }}"
+    that: not item.changed
   loop: "{{ nbde_server_services_state.results }}"
 
 - name: Include the appropriate provider verification tasks

--- a/tests/tests_fetch_keys_deploy_not_set.yml
+++ b/tests/tests_fetch_keys_deploy_not_set.yml
@@ -50,7 +50,7 @@
 
     - name: Verify the common keys are correct
       assert:
-        that: "{{ item.stat.exists }}"
+        that: item.stat.exists
       loop: "{{ nbde_server_local_keys.results }}"
 
 # vim:set ts=2 sw=2 et:

--- a/tests/tests_fetch_keys_deploy_set.yml
+++ b/tests/tests_fetch_keys_deploy_set.yml
@@ -56,7 +56,7 @@
 
     - name: Verify the common keys are correct
       assert:
-        that: "{{ item.stat.exists }}"
+        that: item.stat.exists
       loop: "{{ nbde_server_local_common_keys.results }}"
 
     - name: Gather local host keys to verify deploy
@@ -77,7 +77,7 @@
 
     - name: Verify the keys were deployed
       assert:
-        that: "{{ item.stat.exists }}"
+        that: item.stat.exists
       loop: "{{ nbde_server_deployed_keys.results }}"
 
     - name: Gather local common keys to verify deploy
@@ -98,7 +98,7 @@
 
     - name: Verify the common keys were deployed
       assert:
-        that: "{{ item.stat.exists }}"
+        that: item.stat.exists
       loop: "{{ nbde_server_deployed_common_keys.results }}"
 
 # vim:set ts=2 sw=2 et:

--- a/tests/tests_nbde_server_service_state.yml
+++ b/tests/tests_nbde_server_service_state.yml
@@ -24,7 +24,7 @@
 
     - name: Check whether services were enabled but stopped
       assert:
-        that: "{{ not item.changed }}"
+        that: not item.changed
       loop: "{{ nbde_server_state.results }}"
 
     - name: Accepting connections without specifying state
@@ -42,7 +42,7 @@
 
     - name: Check whether services were enabled and started
       assert:
-        that: "{{ not item.changed }}"
+        that: not item.changed
       loop: "{{ nbde_server_state.results }}"
 
     - name: Accepting connections specifying state started
@@ -62,7 +62,7 @@
 
     - name: Check whether services were enabled and started
       assert:
-        that: "{{ not item.changed }}"
+        that: not item.changed
       loop: "{{ nbde_server_state.results }}"
 
 # vim:set ts=2 sw=2 et:

--- a/tests/tests_tangd_custom_port.yml
+++ b/tests/tests_tangd_custom_port.yml
@@ -45,7 +45,7 @@
             awk -F' ' '{print $1}'
       register: __firewall_output_zone
       failed_when: >-
-        __firewall_output_zone.stdout != "{{ nbde_server_firewall_zone }}"
+        __firewall_output_zone.stdout != nbde_server_firewall_zone
       changed_when: false
 
     - name: Install with default port and firewall zone
@@ -91,7 +91,7 @@
             awk -F' ' '{print $1}'
       register: __firewall_output_zone
       failed_when: >-
-        __firewall_output_zone.stdout != "{{ nbde_server_firewall_zone }}"
+        __firewall_output_zone.stdout != nbde_server_firewall_zone
       changed_when: false
 
 # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
This fixes errors like this:
```
[WARNING]: conditional statements should not include jinja2 templating
delimiters such as {{ }} or {% %}. Found: __firewall_output_zone.stdout != "{{
nbde_server_firewall_zone }}"
```
In Ansible, `when`, `that` and other such conditionals are already
interpreted as Jinja expressions, so you usually don't need quoting
and {{ }}
