### PR TITLE
Fingerprint RHEL System Role managed config files

### DIFF
--- a/templates/tangd_socket_override.conf.j2
+++ b/templates/tangd_socket_override.conf.j2
@@ -1,4 +1,5 @@
 {{ ansible_managed | comment }}
+{{ "system_role:nbde_server" | comment(prefix="", postfix="") }}
 [Socket]
 ListenStream=
 ListenStream={{ nbde_server_port }}


### PR DESCRIPTION
Add role name to the generated config files.
```
# system_role:nbde_server
```
Note: This information is provided to help customers identify that it was generated by System Roles. It may also be used for future analysis.