### PR TITLE
tests: perform cleanup after each test

### DIFF
--- a/tests/tasks/cleanup.yml
+++ b/tests/tasks/cleanup.yml
@@ -1,0 +1,25 @@
+---
+- name: Remove control node files/directories
+  file:
+    path: "{{ nbde_server_keys_dir }}"
+    state: absent
+  when: nbde_server_keys_dir | d("") is match("^/")
+  delegate_to: localhost
+
+- name: Remove managed node files/directories
+  shell: |
+    set -euxo pipefail
+    if [ "{{ item.remove_dir }}" = true ]; then
+      rm -rf "{{ item.path }}"
+    else
+      rm -rf "{{ item.path }}"/* "{{ item.path }}"/.* || :
+    fi
+  changed_when: true
+  loop:
+    - path: "{{ nbde_server_keys_dir | d('') }}"
+      remove_dir: "true"
+    - path: "{{ __nbde_server_keydir | d('') }}"
+      remove_dir: "false"
+    - path: "{{ __nbde_server_cachedir | d('') }}"
+      remove_dir: "false"
+  when: item.path is match("^/")

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -2,10 +2,19 @@
 - name: Ensure that the role runs with default parameters
   hosts: all
   gather_facts: false
-  roles:
-    - linux-system-roles.nbde_server
   tasks:
-    - name: Verify role results
-      include_tasks: tasks/verify-role-results.yml
+    - name: Run test
+      block:
+        - name: Run role
+          include_role:
+            name: linux-system-roles.nbde_server
+            public: true
+
+        - name: Verify role results
+          include_tasks: tasks/verify-role-results.yml
+      always:
+        - name: Cleanup
+          tags: tests::cleanup
+          include_tasks: tasks/cleanup.yml
 
 # vim:set ts=2 sw=2 et:

--- a/tests/tests_default_vars.yml
+++ b/tests/tests_default_vars.yml
@@ -4,9 +4,10 @@
   tasks:
     - name: Run test
       block:
-        - name: Import role
-          import_role:
+        - name: Run role
+          include_role:
             name: linux-system-roles.nbde_server
+            public: true
         - name: Assert that the role declares all parameters in defaults
           assert:
             that: "{{ item }} is defined"
@@ -17,4 +18,9 @@
             - nbde_server_rotate_keys
             - nbde_server_keys_dir
           when: ansible_version.full is version_compare('2.9', '>=')
+      always:
+        - name: Cleanup
+          tags: tests::cleanup
+          include_tasks: tasks/cleanup.yml
+
 # vim:set ts=2 sw=2 et:

--- a/tests/tests_deploy_keys.yml
+++ b/tests/tests_deploy_keys.yml
@@ -6,56 +6,66 @@
 
 - name: Test nbde_server_deploy_keys
   hosts: all
-
-  vars:
-    nbde_server_keys_dir: /tmp/.nbde_server_keys_dir
-
   tasks:
-    - name: Ensure we have keys
-      import_role:
-        name: linux-system-roles.nbde_server
+    - name: Run tests
+      block:
+        - name: Create tmpdir for server keys
+          tempfile:
+            state: directory
+            prefix: nbde_server_deploy_keys
+          register: __tmpdir
+          delegate_to: localhost
 
-    - name: Clean up nbde_server_keys_dir
-      file:
-        path: "{{ nbde_server_keys_dir }}"
-        state: absent
+        - name: Set nbde_server_keys_dir
+          set_fact:
+            nbde_server_keys_dir: "{{ __tmpdir.path }}"
 
-    - name: Fetch the keys from every host
-      import_role:
-        name: linux-system-roles.nbde_server
-      vars:
-        nbde_server_fetch_keys: true
-        nbde_server_deploy_keys: false
+        - name: Ensure we have keys
+          include_role:
+            name: linux-system-roles.nbde_server
 
-    - name: Gather keys before redeploy
-      find:
-        paths: "{{ __nbde_server_keydir }}"
-        hidden: true
-        patterns:
-          - "*.jwk"
-          - ".*.jwk"
-      register: nbde_server_keys_before_redeploy
+        - name: Fetch the keys from every host
+          include_role:
+            name: linux-system-roles.nbde_server
+            public: true
+          vars:
+            nbde_server_fetch_keys: true
+            nbde_server_deploy_keys: false
 
-    - name: Redeploy these same keys
-      import_role:
-        name: linux-system-roles.nbde_server
-      vars:
-        nbde_server_fetch_keys: false
-        nbde_server_deploy_keys: true
+        - name: Gather keys before redeploy
+          find:
+            paths: "{{ __nbde_server_keydir }}"
+            hidden: true
+            patterns:
+              - "*.jwk"
+              - ".*.jwk"
+          register: nbde_server_keys_before_redeploy
 
-    - name: Gather keys after redeploy
-      find:
-        paths: "{{ __nbde_server_keydir }}"
-        hidden: true
-        patterns:
-          - "*.jwk"
-          - ".*.jwk"
-      register: nbde_server_keys_after_redeploy
+        - name: Redeploy these same keys
+          include_role:
+            name: linux-system-roles.nbde_server
+            public: true
+          vars:
+            nbde_server_fetch_keys: false
+            nbde_server_deploy_keys: true
 
-    - name: Verify the keys are the same
-      assert:
-        that: >
-          nbde_server_keys_before_redeploy.files
-          == nbde_server_keys_after_redeploy.files
+        - name: Gather keys after redeploy
+          find:
+            paths: "{{ __nbde_server_keydir }}"
+            hidden: true
+            patterns:
+              - "*.jwk"
+              - ".*.jwk"
+          register: nbde_server_keys_after_redeploy
+
+        - name: Verify the keys are the same
+          assert:
+            that: >
+              nbde_server_keys_before_redeploy.files
+              == nbde_server_keys_after_redeploy.files
+      always:
+        - name: Cleanup
+          tags: tests::cleanup
+          include_tasks: tasks/cleanup.yml
 
 # vim:set ts=2 sw=2 et:

--- a/tests/tests_fetch_keys_deploy_not_set.yml
+++ b/tests/tests_fetch_keys_deploy_not_set.yml
@@ -10,47 +10,57 @@
 
 - name: Test nbde_server_fetch_keys with nbde_server_deploy_keys not set
   hosts: all
-
-  vars:
-    nbde_server_keys_dir: /tmp/.nbde_server_keys_dir
-
   tasks:
-    - name: Ensure we have keys
-      import_role:
-        name: linux-system-roles.nbde_server
+    - name: Run tests
+      block:
+        - name: Create tmpdir for server keys
+          tempfile:
+            state: directory
+            prefix: nbde_server_fetch_keys_deploy_not_set
+          register: __tmpdir
+          delegate_to: localhost
 
-    - name: Gather keys
-      find:
-        paths: "{{ __nbde_server_keydir }}"
-        hidden: true
-        patterns:
-          - "*.jwk"
-          - ".*.jwk"
-      register: nbde_server_host_keys
+        - name: Set nbde_server_keys_dir
+          set_fact:
+            nbde_server_keys_dir: "{{ __tmpdir.path }}"
 
-    - name: Clean up nbde_server_keys_dir
-      file:
-        path: "{{ nbde_server_keys_dir }}"
-        state: absent
+        - name: Ensure we have keys
+          include_role:
+            name: linux-system-roles.nbde_server
+            public: true
 
-    - name: Run with nbde_server_deploy_keys not set to check the keys
-      import_role:
-        name: linux-system-roles.nbde_server
-      vars:
-        nbde_server_rotate_keys: false
-        nbde_server_fetch_keys: true
-        nbde_server_deploy_keys: false
+        - name: Gather keys
+          find:
+            paths: "{{ __nbde_server_keydir }}"
+            hidden: true
+            patterns:
+              - "*.jwk"
+              - ".*.jwk"
+          register: nbde_server_host_keys
 
-    - name: Check whether the keys were properly fetched
-      stat:
-        path: "{{ nbde_server_keys_dir }}/{{ inventory_hostname }}/{{ item.path | basename }}"  # yamllint disable-line rule:line-length
-      loop: "{{ nbde_server_host_keys.files }}"
-      delegate_to: localhost
-      register: nbde_server_local_keys
+        - name: Run with nbde_server_deploy_keys not set to check the keys
+          include_role:
+            name: linux-system-roles.nbde_server
+            public: true
+          vars:
+            nbde_server_rotate_keys: false
+            nbde_server_fetch_keys: true
+            nbde_server_deploy_keys: false
 
-    - name: Verify the common keys are correct
-      assert:
-        that: item.stat.exists
-      loop: "{{ nbde_server_local_keys.results }}"
+        - name: Check whether the keys were properly fetched
+          stat:
+            path: "{{ nbde_server_keys_dir }}/{{ inventory_hostname }}/{{ item.path | basename }}"  # yamllint disable-line rule:line-length
+          loop: "{{ nbde_server_host_keys.files }}"
+          delegate_to: localhost
+          register: nbde_server_local_keys
+
+        - name: Verify the common keys are correct
+          assert:
+            that: item.stat.exists
+          loop: "{{ nbde_server_local_keys.results }}"
+      always:
+        - name: Cleanup
+          tags: tests::cleanup
+          include_tasks: tasks/cleanup.yml
 
 # vim:set ts=2 sw=2 et:

--- a/tests/tests_fetch_keys_deploy_set.yml
+++ b/tests/tests_fetch_keys_deploy_set.yml
@@ -15,90 +15,100 @@
 
 - name: Test nbde_server_fetch_keys with nbde_server_deploy_keys set
   hosts: all
-
-  vars:
-    nbde_server_keys_dir: /tmp/.nbde_server_keys_dir
-
   tasks:
-    - name: Ensure we have keys
-      import_role:
-        name: linux-system-roles.nbde_server
+    - name: Run tests
+      block:
+        - name: Create tmpdir for server keys
+          tempfile:
+            state: directory
+            prefix: nbde_server_fetch_keys_deploy_set
+          register: __tmpdir
+          delegate_to: localhost
 
-    - name: Gather common keys, from the first host in the inventory
-      run_once: true
-      find:
-        paths: "{{ __nbde_server_keydir }}"
-        hidden: true
-        patterns:
-          - "*.jwk"
-          - ".*.jwk"
-      register: nbde_server_host_common_keys
+        - name: Set nbde_server_keys_dir
+          set_fact:
+            nbde_server_keys_dir: "{{ __tmpdir.path }}"
 
-    - name: Clean up nbde_server_keys_dir
-      file:
-        path: "{{ nbde_server_keys_dir }}"
-        state: absent
+        - name: Ensure we have keys
+          include_role:
+            name: linux-system-roles.nbde_server
+            public: true
 
-    - name: Run with nbde_server_deploy_keys set to check the common keys
-      import_role:
-        name: linux-system-roles.nbde_server
-      vars:
-        nbde_server_rotate_keys: false
-        nbde_server_fetch_keys: true
-        nbde_server_deploy_keys: true
+        - name: Gather common keys, from the first host in the inventory
+          run_once: true
+          find:
+            paths: "{{ __nbde_server_keydir }}"
+            hidden: true
+            patterns:
+              - "*.jwk"
+              - ".*.jwk"
+          register: nbde_server_host_common_keys
 
-    - name: Check whether the common keys were properly fetched
-      stat:
-        path: "{{ nbde_server_keys_dir }}/{{ item.path | basename }}"
-      loop: "{{ nbde_server_host_common_keys.files }}"
-      delegate_to: localhost
-      register: nbde_server_local_common_keys
+        - name: Run with nbde_server_deploy_keys set to check the common keys
+          include_role:
+            name: linux-system-roles.nbde_server
+            public: true
+          vars:
+            nbde_server_rotate_keys: false
+            nbde_server_fetch_keys: true
+            nbde_server_deploy_keys: true
 
-    - name: Verify the common keys are correct
-      assert:
-        that: item.stat.exists
-      loop: "{{ nbde_server_local_common_keys.results }}"
+        - name: Check whether the common keys were properly fetched
+          stat:
+            path: "{{ nbde_server_keys_dir }}/{{ item.path | basename }}"
+          loop: "{{ nbde_server_host_common_keys.files }}"
+          delegate_to: localhost
+          register: nbde_server_local_common_keys
 
-    - name: Gather local host keys to verify deploy
-      find:
-        paths: "{{ nbde_server_keys_dir }}/{{ inventory_hostname }}"
-        hidden: true
-        patterns:
-          - "*.jwk"
-          - ".*.jwk"
-      delegate_to: localhost
-      register: nbde_server_local_host_keys
+        - name: Verify the common keys are correct
+          assert:
+            that: item.stat.exists
+          loop: "{{ nbde_server_local_common_keys.results }}"
 
-    - name: Check whether the host keys were properly deployed
-      stat:
-        path: "{{ __nbde_server_keydir }}/{{ item.path | basename }}"
-      loop: "{{ nbde_server_local_host_keys.files }}"
-      register: nbde_server_deployed_keys
+        - name: Gather local host keys to verify deploy
+          find:
+            paths: "{{ nbde_server_keys_dir }}/{{ inventory_hostname }}"
+            hidden: true
+            patterns:
+              - "*.jwk"
+              - ".*.jwk"
+          delegate_to: localhost
+          register: nbde_server_local_host_keys
 
-    - name: Verify the keys were deployed
-      assert:
-        that: item.stat.exists
-      loop: "{{ nbde_server_deployed_keys.results }}"
+        - name: Check whether the host keys were properly deployed
+          stat:
+            path: "{{ __nbde_server_keydir }}/{{ item.path | basename }}"
+          loop: "{{ nbde_server_local_host_keys.files }}"
+          register: nbde_server_deployed_keys
 
-    - name: Gather local common keys to verify deploy
-      find:
-        paths: "{{ nbde_server_keys_dir }}"
-        hidden: true
-        patterns:
-          - "*.jwk"
-          - ".*.jwk"
-      delegate_to: localhost
-      register: nbde_server_local_common_keys
+        - name: Verify the keys were deployed
+          assert:
+            that: item.stat.exists
+          loop: "{{ nbde_server_deployed_keys.results }}"
 
-    - name: Check whether the local common keys were properly deployed
-      stat:
-        path: "{{ __nbde_server_keydir }}/{{ item.path | basename }}"
-      loop: "{{ nbde_server_local_common_keys.files }}"
-      register: nbde_server_deployed_common_keys
+        - name: Gather local common keys to verify deploy
+          find:
+            paths: "{{ nbde_server_keys_dir }}"
+            hidden: true
+            patterns:
+              - "*.jwk"
+              - ".*.jwk"
+          delegate_to: localhost
+          register: nbde_server_local_common_keys
 
-    - name: Verify the common keys were deployed
-      assert:
-        that: item.stat.exists
-      loop: "{{ nbde_server_deployed_common_keys.results }}"
+        - name: Check whether the local common keys were properly deployed
+          stat:
+            path: "{{ __nbde_server_keydir }}/{{ item.path | basename }}"
+          loop: "{{ nbde_server_local_common_keys.files }}"
+          register: nbde_server_deployed_common_keys
+
+        - name: Verify the common keys were deployed
+          assert:
+            that: item.stat.exists
+          loop: "{{ nbde_server_deployed_common_keys.results }}"
+      always:
+        - name: Cleanup
+          tags: tests::cleanup
+          include_tasks: tasks/cleanup.yml
 
 # vim:set ts=2 sw=2 et:

--- a/tests/tests_include_vars_from_parent.yml
+++ b/tests/tests_include_vars_from_parent.yml
@@ -39,8 +39,13 @@
           map('join') | product(versions) | map('join') | list +
           [facts['distribution'], facts['os_family']] }}"
 
-    - name: Import role
-      import_role:
+    - name: Include role
+      include_role:
         name: caller
+        public: true
       vars:
         roletoinclude: linux-system-roles.nbde_server
+
+    - name: Cleanup
+      tags: tests::cleanup
+      include_tasks: tasks/cleanup.yml

--- a/tests/tests_nbde_server_keys_dir.yml
+++ b/tests/tests_nbde_server_keys_dir.yml
@@ -9,8 +9,9 @@
     - name: Test 1 - only nbde_server_fetch_keys set
       block:
         - name: With nbde_server_fetch_keys
-          import_role:
+          include_role:
             name: linux-system-roles.nbde_server
+            public: true
           vars:
             nbde_server_fetch_keys: true
 
@@ -22,12 +23,18 @@
         - name: Check for error with nbde_server_keys_dir not set
           assert:
             that: ansible_failed_result.msg != 'UNREACH'
+
+      always:
+        - name: Cleanup
+          tags: tests::cleanup
+          include_tasks: tasks/cleanup.yml
 
     - name: Test 2 - only nbde_server_deploy_keys set
       block:
         - name: With nbde_server_deploy_keys
-          import_role:
+          include_role:
             name: linux-system-roles.nbde_server
+            public: true
           vars:
             nbde_server_deploy_keys: true
 
@@ -40,11 +47,17 @@
           assert:
             that: ansible_failed_result.msg != 'UNREACH'
 
+      always:
+        - name: Cleanup
+          tags: tests::cleanup
+          include_tasks: tasks/cleanup.yml
+
     - name: Test 3 - nbde_server_fetch_keys and nbde_server_deploy_keys set
       block:
         - name: With nbde_server_fetch_keys and deploy keys
-          import_role:
+          include_role:
             name: linux-system-roles.nbde_server
+            public: true
           vars:
             nbde_server_fetch_keys: true
             nbde_server_deploy_keys: true
@@ -58,11 +71,17 @@
           assert:
             that: ansible_failed_result.msg != 'UNREACH'
 
+      always:
+        - name: Cleanup
+          tags: tests::cleanup
+          include_tasks: tasks/cleanup.yml
+
     - name: Test 4 - nbde_server_keys_dir is absolute path
       block:
         - name: Directory starting with ./
-          import_role:
+          include_role:
             name: linux-system-roles.nbde_server
+            public: true
           vars:
             nbde_server_fetch_keys: true
             nbde_server_keys_dir: ./foobar
@@ -76,11 +95,17 @@
           assert:
             that: ansible_failed_result.msg != 'UNREACH'
 
+      always:
+        - name: Cleanup
+          tags: tests::cleanup
+          include_tasks: tasks/cleanup.yml
+
     - name: Test 5 - nbde_server_keys_dir is absolute path
       block:
         - name: Directory without leading ./
-          import_role:
+          include_role:
             name: linux-system-roles.nbde_server
+            public: true
           vars:
             nbde_server_fetch_keys: true
             nbde_server_keys_dir: foobar
@@ -93,5 +118,10 @@
         - name: Check for error with nbde_server_keys_dir not an absolute path
           assert:
             that: ansible_failed_result.msg != 'UNREACH'
+
+      always:
+        - name: Cleanup
+          tags: tests::cleanup
+          include_tasks: tasks/cleanup.yml
 
 # vim:set ts=2 sw=2 et:

--- a/tests/tests_nbde_server_rotate_keys.yml
+++ b/tests/tests_nbde_server_rotate_keys.yml
@@ -7,61 +7,70 @@
   hosts: all
 
   tasks:
-    - name: Ensure we have keys
-      import_role:
-        name: linux-system-roles.nbde_server
+    - name: Run tests
+      block:
+        - name: Ensure we have keys
+          include_role:
+            name: linux-system-roles.nbde_server
+            public: true
 
-    - name: Gather keys
-      find:
-        paths: "{{ __nbde_server_keydir }}"
-        file_type: file
-        recurse: false
-        patterns:
-          - "*.jwk"
-          - ".*.jwk"
-      check_mode: true
-      register: nbde_server_keys
+        - name: Gather keys
+          find:
+            paths: "{{ __nbde_server_keydir }}"
+            file_type: file
+            recurse: false
+            patterns:
+              - "*.jwk"
+              - ".*.jwk"
+          check_mode: true
+          register: nbde_server_keys
 
-    - name: Run with nbde_server_rotate_keys not set to check keys
-      import_role:
-        name: linux-system-roles.nbde_server
-      vars:
-        nbde_server_rotate_keys: false
+        - name: Run with nbde_server_rotate_keys not set to check keys
+          include_role:
+            name: linux-system-roles.nbde_server
+            public: true
+          vars:
+            nbde_server_rotate_keys: false
 
-    - name: Gather keys after running with nbde_server_rotate_keys not set
-      find:
-        paths: "{{ __nbde_server_keydir }}"
-        file_type: file
-        recurse: false
-        patterns:
-          - "*.jwk"
-          - ".*.jwk"
-      check_mode: true
-      register: nbde_server_rotate_not_set
+        - name: Gather keys after running with nbde_server_rotate_keys not set
+          find:
+            paths: "{{ __nbde_server_keydir }}"
+            file_type: file
+            recurse: false
+            patterns:
+              - "*.jwk"
+              - ".*.jwk"
+          check_mode: true
+          register: nbde_server_rotate_not_set
 
-    - name: Check whether keys changed - nbde_server_rotate_keys not set
-      assert:
-        that: nbde_server_keys.files == nbde_server_rotate_not_set.files
+        - name: Check whether keys changed - nbde_server_rotate_keys not set
+          assert:
+            that: nbde_server_keys.files == nbde_server_rotate_not_set.files
 
-    - name: Run with nbde_server_rotate_keys set to check keys
-      import_role:
-        name: linux-system-roles.nbde_server
-      vars:
-        nbde_server_rotate_keys: true
+        - name: Run with nbde_server_rotate_keys set to check keys
+          include_role:
+            name: linux-system-roles.nbde_server
+            public: true
+          vars:
+            nbde_server_rotate_keys: true
 
-    - name: Gather keys after running with nbde_server_rotate_keys set
-      find:
-        paths: "{{ __nbde_server_keydir }}"
-        file_type: file
-        recurse: false
-        patterns:
-          - "*.jwk"
-          - ".*.jwk"
-      check_mode: true
-      register: nbde_server_rotate_set
+        - name: Gather keys after running with nbde_server_rotate_keys set
+          find:
+            paths: "{{ __nbde_server_keydir }}"
+            file_type: file
+            recurse: false
+            patterns:
+              - "*.jwk"
+              - ".*.jwk"
+          check_mode: true
+          register: nbde_server_rotate_set
 
-    - name: Check whether keys changed - nbde_server_rotate_keys set
-      assert:
-        that: nbde_server_keys.files != nbde_server_rotate_set.files
+        - name: Check whether keys changed - nbde_server_rotate_keys set
+          assert:
+            that: nbde_server_keys.files != nbde_server_rotate_set.files
+      always:
+        - name: Cleanup
+          tags: tests::cleanup
+          include_tasks: tasks/cleanup.yml
 
 # vim:set ts=2 sw=2 et:

--- a/tests/tests_nbde_server_service_state.yml
+++ b/tests/tests_nbde_server_service_state.yml
@@ -7,62 +7,71 @@
   hosts: all
 
   tasks:
-    - name: Not accepting connections specifying state stopped
-      import_role:
-        name: linux-system-roles.nbde_server
-      vars:
-        nbde_server_service_state: stopped
+    - name: Run tests
+      block:
+        - name: Accepting connections without specifying state
+          include_role:
+            name: linux-system-roles.nbde_server
+            public: true
 
-    - name: Gather state of services
-      service:
-        name: "{{ item }}"
-        enabled: true
-        state: stopped
-      register: nbde_server_state
-      check_mode: true
-      loop: "{{ __nbde_server_services }}"
+        - name: Gather state of services
+          service:
+            name: "{{ item }}"
+            enabled: true
+            state: started
+          register: nbde_server_state
+          check_mode: true
+          loop: "{{ __nbde_server_services }}"
 
-    - name: Check whether services were enabled but stopped
-      assert:
-        that: not item.changed
-      loop: "{{ nbde_server_state.results }}"
+        - name: Check whether services were enabled and started
+          assert:
+            that: not item.changed
+          loop: "{{ nbde_server_state.results }}"
 
-    - name: Accepting connections without specifying state
-      import_role:
-        name: linux-system-roles.nbde_server
+        - name: Not accepting connections specifying state stopped
+          include_role:
+            name: linux-system-roles.nbde_server
+            public: true
+          vars:
+            nbde_server_service_state: stopped
 
-    - name: Gather state of services
-      service:
-        name: "{{ item }}"
-        enabled: true
-        state: started
-      register: nbde_server_state
-      check_mode: true
-      loop: "{{ __nbde_server_services }}"
+        - name: Gather state of services
+          service:
+            name: "{{ item }}"
+            enabled: true
+            state: stopped
+          register: nbde_server_state
+          check_mode: true
+          loop: "{{ __nbde_server_services }}"
 
-    - name: Check whether services were enabled and started
-      assert:
-        that: not item.changed
-      loop: "{{ nbde_server_state.results }}"
+        - name: Check whether services were enabled but stopped
+          assert:
+            that: not item.changed
+          loop: "{{ nbde_server_state.results }}"
 
-    - name: Accepting connections specifying state started
-      import_role:
-        name: linux-system-roles.nbde_server
-      vars:
-        nbde_server_service_state: started
+        - name: Accepting connections specifying state started
+          include_role:
+            name: linux-system-roles.nbde_server
+            public: true
+          vars:
+            nbde_server_service_state: started
 
-    - name: Gather state of services
-      service:
-        name: "{{ item }}"
-        enabled: true
-        state: started
-      register: nbde_server_state
-      check_mode: true
-      loop: "{{ __nbde_server_services }}"
+        - name: Gather state of services
+          service:
+            name: "{{ item }}"
+            enabled: true
+            state: started
+          register: nbde_server_state
+          check_mode: true
+          loop: "{{ __nbde_server_services }}"
 
-    - name: Check whether services were enabled and started
-      assert:
-        that: not item.changed
-      loop: "{{ nbde_server_state.results }}"
+        - name: Check whether services were enabled and started
+          assert:
+            that: not item.changed
+          loop: "{{ nbde_server_state.results }}"
+      always:
+        - name: Cleanup
+          tags: tests::cleanup
+          include_tasks: tasks/cleanup.yml
 
 # vim:set ts=2 sw=2 et:

--- a/tests/tests_tangd_custom_port.yml
+++ b/tests/tests_tangd_custom_port.yml
@@ -7,82 +7,92 @@
     nbde_server_manage_firewall: true
     nbde_server_manage_selinux: true
   tasks:
-    - name: Install with custom port and firewall zone
-      include_role:
-        name: linux-system-roles.nbde_server
+    - name: Run tests
+      block:
+        - name: Install with custom port and firewall zone
+          include_role:
+            name: linux-system-roles.nbde_server
+            public: true
 
-    - name: Ensure iproute package for ss command
-      package:
-        name: iproute
-        state: present
-        use: "{{ (__nbde_server_is_ostree | d(false)) |
-                 ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
+        - name: Ensure iproute package for ss command
+          package:
+            name: iproute
+            state: present
+            use: "{{ (__nbde_server_is_ostree | d(false)) |
+                    ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
-    - name: Check if port is open
-      shell:
-        cmd: |-
-          set -euo pipefail
-          ss -tulpn | grep ':{{ nbde_server_port }} ' | awk -F' ' '{print $5}'
-      register: __open_ports_output
-      failed_when: not __open_ports_output.stdout is
-        search(':' ~ (nbde_server_port | string) ~ '$')
-      changed_when: false
+        - name: Check if port is open
+          shell:
+            cmd: |-
+              set -euo pipefail
+              ss -tulpn | grep ':{{ nbde_server_port }} ' | \
+                awk -F' ' '{print $5}'
+          register: __open_ports_output
+          failed_when: not __open_ports_output.stdout is
+            search(':' ~ (nbde_server_port | string) ~ '$')
+          changed_when: false
 
-    - name: Check if port TCP is open
-      shell:
-        cmd: |-
-          set -euo pipefail
-          ss -tulpn | grep ':{{ nbde_server_port }} ' | awk -F' ' '{print $1}'
-      register: __open_ports_output
-      failed_when: __open_ports_output.stdout != "tcp"
-      changed_when: false
+        - name: Check if port TCP is open
+          shell:
+            cmd: |-
+              set -euo pipefail
+              ss -tulpn | grep ':{{ nbde_server_port }} ' | \
+                awk -F' ' '{print $1}'
+          register: __open_ports_output
+          failed_when: __open_ports_output.stdout != "tcp"
+          changed_when: false
 
-    - name: Check if port is opened in firewall
-      command: >-
-        firewall-cmd --zone {{ nbde_server_firewall_zone }} --query-port
-        {{ nbde_server_port }}/tcp
-      register: __firewall_output
-      changed_when: false
+        - name: Check if port is opened in firewall
+          command: >-
+            firewall-cmd --zone {{ nbde_server_firewall_zone }} --query-port
+            {{ nbde_server_port }}/tcp
+          register: __firewall_output
+          changed_when: false
 
-    - name: Check for ansible_managed, fingerprint in generated files
-      include_tasks: tasks/check_header.yml
-      vars:
-        __file: /etc/systemd/system/tangd.socket.d/override.conf
-        __fingerprint: "system_role:nbde_server"
+        - name: Check for ansible_managed, fingerprint in generated files
+          include_tasks: tasks/check_header.yml
+          vars:
+            __file: /etc/systemd/system/tangd.socket.d/override.conf
+            __fingerprint: "system_role:nbde_server"
 
-    - name: Install with default port and firewall zone
-      include_role:
-        name: linux-system-roles.nbde_server
-      vars:
-        nbde_server_port: 80
-        nbde_server_firewall_zone: public
-        nbde_server_manage_firewall: true
-        nbde_server_manage_selinux: true
+        - name: Install with default port and firewall zone
+          include_role:
+            name: linux-system-roles.nbde_server
+            public: true
+          vars:
+            nbde_server_port: 80
+            nbde_server_firewall_zone: public
+            nbde_server_manage_firewall: true
+            nbde_server_manage_selinux: true
 
-    - name: Check if port is open
-      shell:
-        cmd: |-
-          set -euo pipefail
-          ss -tulpn | grep ':80 ' | awk -F' ' '{print $5}'
-      register: __open_ports_output
-      failed_when: not __open_ports_output.stdout is
-        search(':80$')
-      changed_when: false
+        - name: Check if port is open
+          shell:
+            cmd: |-
+              set -euo pipefail
+              ss -tulpn | grep ':80 ' | awk -F' ' '{print $5}'
+          register: __open_ports_output
+          failed_when: not __open_ports_output.stdout is
+            search(':80$')
+          changed_when: false
 
-    - name: Check if port TCP is open
-      shell:
-        cmd: |-
-          set -euo pipefail
-          ss -tulpn | grep ':80 ' | awk -F' ' '{print $1}'
-      register: __open_ports_output
-      failed_when: __open_ports_output.stdout != "tcp"
-      changed_when: false
+        - name: Check if port TCP is open
+          shell:
+            cmd: |-
+              set -euo pipefail
+              ss -tulpn | grep ':80 ' | awk -F' ' '{print $1}'
+          register: __open_ports_output
+          failed_when: __open_ports_output.stdout != "tcp"
+          changed_when: false
 
-    - name: Check if port is opened in firewall
-      command: >-
-        firewall-cmd --zone {{ nbde_server_firewall_zone }} --query-port
-        80/tcp
-      register: __firewall_output
-      changed_when: false
+        - name: Check if port is opened in firewall
+          command: >-
+            firewall-cmd --zone {{ nbde_server_firewall_zone }} --query-port
+            80/tcp
+          register: __firewall_output
+          changed_when: false
+      always:
+        - name: Cleanup
+          tags: tests::cleanup
+          include_tasks: tasks/cleanup.yml
 
 # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
I'm seeing several test flakes which I believe are due to
files/directories being left over after each run.  I've added
code to ensure cleanup:

* tests/tasks/cleanup.yml will remove leftover files/directories
  from both the control node and the managed node
* Use `include_role` with `public: true` instead of `import_role`
  in order to get role private variables
* Wrap tests in `block`/`always` to ensure clean up always runs

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
