### PR TITLE
fix: Allow tangd socket override directory to be managed outside of the role

### DIFF
--- a/tasks/tangd-custom-port.yml
+++ b/tasks/tangd-custom-port.yml
@@ -11,14 +11,34 @@
         local: true
   when: nbde_server_manage_selinux | bool
 
+- name: Stat the tangd custom port systemd directory
+  stat:
+    path: "{{ __nbde_server_tangd_socket_dir }}"
+  register: __nbde_server_tangd_dir_stat
+
+- name: Get a list of files in the tangd custom directory
+  find:
+    paths: "{{ __nbde_server_tangd_socket_dir }}"
+    file_type: any
+    hidden: true
+    excludes: ["^{{ __nbde_server_tangd_socket_file_name }}$"]
+    use_regex: true
+  register: __nbde_server_tangd_socket_file_list
+  when:
+    - __nbde_server_tangd_dir_stat.stat.exists
+    - nbde_server_port | int == 80
+
 # If using default port, ensure directory does not exist
 # If not using default port, create directory
+# Do not remove the directory unless it is empty
+# Do not modify the directory if it exists
 - name: Manage tangd custom port systemd directory
   file:
-    path: /etc/systemd/system/tangd.socket.d
-    state: "{{ (nbde_server_port | int == 80) |
-      ternary('absent', 'directory') }}"
-    mode: "0755"
+    path: "{{ __nbde_server_tangd_socket_dir }}"
+    state: "{{ 'absent' if ((nbde_server_port | int == 80) and
+      (__nbde_server_tangd_socket_file_list.matched | d(0) == 0))
+      else 'directory' }}"
+    mode: "{{ __nbde_server_tangd_dir_stat.stat.mode | d('0755') }}"
   register: __nbde_server_custom_dir
 
 # This tasks creates the file with the port entry that we want tangd to
@@ -26,7 +46,7 @@
 - name: Creates the file with the port entry that we want tangd to listen to
   template:
     src: tangd_socket_override.conf.j2
-    dest: /etc/systemd/system/tangd.socket.d/override.conf
+    dest: "{{ __nbde_server_tangd_socket_file_path }}"
     backup: true
     mode: "0644"
   when: nbde_server_port | int != 80

--- a/tests/tests_share_system_dir.yml
+++ b/tests/tests_share_system_dir.yml
@@ -1,0 +1,108 @@
+---
+- name: >-
+    Ensure that the role can share tangd.socket.d directory with other
+    files
+  hosts: all
+  gather_facts: false
+  vars:
+    maxcon_conf: /etc/systemd/system/tangd.socket.d/override2.conf
+    tangd_dir_mode: "0775"
+    tangd_file_mode: "0664"
+  tasks:
+    - name: Run test
+      block:
+        - name: Create the tangd.socket.d directory
+          file:
+            path: /etc/systemd/system/tangd.socket.d
+            state: directory
+            mode: "{{ tangd_dir_mode }}"
+
+        - name: Create a customization systemd file
+          copy:
+            content: |
+              [Socket]
+              MaxConnections=128
+            dest: "{{ maxcon_conf }}"
+            mode: "{{ tangd_file_mode }}"
+
+        - name: Run role
+          include_role:
+            name: linux-system-roles.nbde_server
+            public: true  # only need this the first time to get private vars
+
+        - name: Check tangd socket dir
+          stat:
+            path: "{{ __nbde_server_tangd_socket_dir }}"
+          register: __stat
+          failed_when: not __stat.stat.exists or
+            __stat.stat.mode != tangd_dir_mode
+
+        - name: Check custom file
+          stat:
+            path: "{{ maxcon_conf }}"
+          register: __stat
+          failed_when: not __stat.stat.exists or
+            __stat.stat.mode != tangd_file_mode
+
+        - name: Verify role reported no changes
+          assert:
+            that: not __nbde_server_custom_dir is changed
+
+        - name: Run the role with a custom port
+          include_role:
+            name: linux-system-roles.nbde_server
+          vars:
+            nbde_server_port: 7500
+            nbde_server_firewall_zone: public
+            nbde_server_manage_firewall: true
+            nbde_server_manage_selinux: true
+
+        - name: Check tangd socket dir
+          stat:
+            path: "{{ __nbde_server_tangd_socket_dir }}"
+          register: __stat
+          failed_when: not __stat.stat.exists or
+            __stat.stat.mode != tangd_dir_mode
+
+        - name: Check custom file
+          stat:
+            path: "{{ maxcon_conf }}"
+          register: __stat
+          failed_when: not __stat.stat.exists or
+            __stat.stat.mode != tangd_file_mode
+
+        - name: Verify role reported no changes
+          assert:
+            that: not __nbde_server_custom_dir is changed
+
+        - name: Check for ansible_managed, fingerprint in generated files
+          include_tasks: tasks/check_header.yml
+          vars:
+            __file: "{{ __nbde_server_tangd_socket_file_path }}"
+            __fingerprint: "system_role:nbde_server"
+
+        - name: Remove custom file
+          file:
+            path: "{{ maxcon_conf }}"
+            state: absent
+
+        - name: Run the role with default port
+          include_role:
+            name: linux-system-roles.nbde_server
+
+        - name: Check tangd socket dir is absent
+          stat:
+            path: "{{ __nbde_server_tangd_socket_dir }}"
+          register: __stat
+          failed_when: __stat.stat.exists
+
+      always:
+        - name: Debug
+          command: journalctl -ex
+          changed_when: false
+
+        - name: Cleanup
+          tags: tests::cleanup
+          include_tasks: tasks/cleanup.yml
+
+# vim:set ts=2 sw=2 et:

--- a/tests/tests_tangd_custom_port.yml
+++ b/tests/tests_tangd_custom_port.yml
@@ -52,7 +52,7 @@
         - name: Check for ansible_managed, fingerprint in generated files
           include_tasks: tasks/check_header.yml
           vars:
-            __file: /etc/systemd/system/tangd.socket.d/override.conf
+            __file: "{{ __nbde_server_tangd_socket_file_path }}"
             __fingerprint: "system_role:nbde_server"
 
         - name: Install with default port and firewall zone

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: MIT
 ---
+__nbde_server_tangd_socket_dir: /etc/systemd/system/tangd.socket.d
+__nbde_server_tangd_socket_file_name: override.conf
+__nbde_server_tangd_socket_file_path: "{{
+  __nbde_server_tangd_socket_dir}}/{{ __nbde_server_tangd_socket_file_name }}"
+
 # ansible_facts required by the role
 __nbde_server_required_facts:
   - distribution


### PR DESCRIPTION
Cause: The role was assuming that the only file being managed in the tangd
socket override directory was the override.conf file for the custom port.

Consequence: The role would delete the directory if there was no custom port
without checking if there were other files in that directory being used to
override tangd settings.  This would cause the directory to be recreated
upon subsequent runs, and the role would report a change, and not appear
to be idempotent.

Fix: When adding the override directory for the port override file, do not
change its attributes.  Do not delete the directory if there are other files
in it.

Result: The role will co-exist with the tangd socket override files being
managed outside of the role.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

Fixes https://github.com/linux-system-roles/nbde_server/issues/138
