### PR TITLE
docs(changelog): version 1.4.10 [citest skip]

### DIFF
--- a/.README.html
+++ b/.README.html
@@ -58,8 +58,9 @@ SOFTWARE.
   </style>
   <style type="text/css">code{white-space: pre;}</style>
   <style type="text/css">
+html { -webkit-text-size-adjust: 100%; }
 pre > code.sourceCode { white-space: pre; position: relative; }
-pre > code.sourceCode > span { line-height: 1.25; }
+pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
 pre > code.sourceCode > span:empty { height: 1.2em; }
 .sourceCode { overflow: visible; }
 code.sourceCode > span { color: inherit; text-decoration: inherit; }
@@ -70,7 +71,7 @@ div.sourceCode { overflow: auto; }
 }
 @media print {
 pre > code.sourceCode { white-space: pre-wrap; }
-pre > code.sourceCode > span { display: inline-block; text-indent: -5em; padding-left: 5em; }
+pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
 }
 pre.numberSource code
   { counter-reset: source-line 0; }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 Changelog
 =========
 
+[1.4.10] - 2025-05-21
+--------------------
+
+### Other Changes
+
+- ci: ansible-plugin-scan is disabled for now (#170)
+- ci: bump ansible-lint to v25; provide collection requirements for ansible-lint (#173)
+- refactor: fix python black formatting (#174)
+- ci: Check spelling with codespell (#175)
+- ci: Add test plan that runs CI tests and customize it for each role (#176)
+- ci: In test plans, prefix all relate variables with SR_ (#177)
+- ci: Fix bug with ARTIFACTS_URL after prefixing with SR_ (#178)
+- ci: several changes related to new qemu test, ansible-lint, python versions, ubuntu versions (#179)
+- ci: use tox-lsr 3.6.0; improve qemu test logging (#180)
+- ci: skip storage scsi, nvme tests in github qemu ci (#181)
+- ci: Bump sclorg/testing-farm-as-github-action from 3 to 4 (#182)
+- ci: bump tox-lsr to 3.8.0; rename qemu/kvm tests (#183)
+- ci: Add Fedora 42; use tox-lsr 3.9.0; use lsr-report-errors for qemu tests (#184)
+
 [1.4.9] - 2025-01-09
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.4.10

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Document version 1.4.10 changes and refine README HTML code block styling

Documentation:
- Add CHANGELOG entry for version 1.4.10 covering CI updates and refactoring
- Adjust README HTML code block CSS for consistent display and indentation