### PR TITLE
docs(changelog): version 1.5.0 [citest skip]

### DIFF
--- a/.README.html
+++ b/.README.html
@@ -201,7 +201,7 @@ can set up tang servers.</p>
 <code>meta/collection-requirements.yml</code>. These are not
 automatically installed. You must install them like this:</p>
 <div class="sourceCode" id="cb1"><pre
-class="sourceCode bash"><code class="sourceCode bash"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="ex">ansible-galaxy</span> install <span class="at">-vv</span> <span class="at">-r</span> meta/collection-requirements.yml<span class="kw">`</span></span></code></pre></div>
+class="sourceCode bash"><code class="sourceCode bash"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="ex">ansible-galaxy</span> install <span class="at">-vv</span> <span class="at">-r</span> meta/collection-requirements.yml</span></code></pre></div>
 <h1 id="role-variables">Role Variables</h1>
 <p>These are the variables that can be passed to the role:</p>
 <table>
@@ -227,7 +227,9 @@ able to provision/deploy tang servers.</td>
 <td>indicates the state the nbde_server should be. It can be either
 <code>started</code> (default) or <code>stopped</code>.
 <code>started</code> means the server is accepting connections, whereas
-<code>stopped</code> means it is not accepting connections.</td>
+<code>stopped</code> means it is not accepting connections. Ignored for
+non-booted hosts like container builds, then the service is always
+started at boot.</td>
 </tr>
 <tr>
 <td><code>nbde_server_rotate_keys</code></td>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+[1.5.0] - 2025-06-23
+--------------------
+
+### New Features
+
+- feat: Support this role in container builds (#188)
+
+### Other Changes
+
+- ci: Add support for bootc end-to-end validation tests (#186)
+- ci: Use ansible 2.19 for fedora 42 testing; support python 3.13 (#187)
+
 [1.4.10] - 2025-05-21
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.5.0

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Prepare the 1.5.0 release by introducing container build support, enhancing CI testing workflows, and updating documentation.

New Features:
- Support this role in container builds

CI:
- Add support for bootc end-to-end validation tests
- Use Ansible 2.19 for Fedora 42 testing and add Python 3.13 support

Documentation:
- Update CHANGELOG for version 1.5.0 release
- Fix code block formatting in README
- Clarify nbde_server behavior for container builds in documentation