### PR TITLE
docs(changelog): version 1.6.0 [citest_skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,34 @@
 Changelog
 =========
 
+[1.6.0] - 2026-04-28
+--------------------
+
+### New Features
+
+- feat: add role fingerprints to syslog (#232)
+
+### Other Changes
+
+- ci: use ANSIBLE_INJECT_FACT_VARS=false by default for testing (#212)
+- ci: Bump ansible/ansible-lint from 25 to 26 (#213)
+- ci: skip most CI checks if title contains citest skip [citest_skip] (#214)
+- ci: ansible-lint - remove .collection directory from converted collection [citest_skip] (#215)
+- ci: tox-lsr version 3.15.0 [citest_skip] (#216)
+- ci: Add Fedora 43, remove Fedora 41 from Testing Farm CI (#217)
+- ci: Bump actions/upload-artifact from 6 to 7 (#219)
+- ci: tox-lsr 3.17.0 - container test improvements, use ansible 2.20 for fedora 43 [citest_skip] (#221)
+- ci: tox-lsr 3.17.1 - previous update broke container tests, this fixes them [citest_skip] (#222)
+- test: ensure role gathers the facts it uses by having test clear_facts before include_role (#223)
+- ci: Bump codecov/codecov-action from 5 to 6 (#224)
+- ci: fix yum repos to use devel site instead of old site name [citest_skip] (#225)
+- ci: use codecov @v6 [citest_skip] (#226)
+- refactor: comply with Ansible partner certification checks (#227)
+- ci: update header for run_role_with_clear_facts [citest_skip] (#228)
+- test: support ansible-test milestone version 2.22 [citest_skip] (#229)
+- ci: Comply with Ansible partner certification checking [citest_skip] (#230)
+- ci: ansible-lint requires dependencies to be installed [citest_skip] (#231)
+
 [1.5.2] - 2026-01-07
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.6.0

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Documentation:
- Add 1.6.0 release entry to the changelog summarizing the new feature and CI/test updates.