### PR TITLE
fix: firewall - use runtime instead of deprecated immediate

### DIFF
--- a/tasks/tangd-custom-port.yml
+++ b/tasks/tangd-custom-port.yml
@@ -66,6 +66,6 @@
       - port: "{{ nbde_server_port }}/tcp"
         zone: "{{ nbde_server_firewall_zone }}"
         state: enabled
-        immediate: true
+        runtime: "{{ __nbde_server_is_booted }}"
         permanent: true
   when: nbde_server_manage_firewall | bool


### PR DESCRIPTION
Cause: The parameter "immediate" has been deprecated.

Consequence: The firewall role gives an error about deprecated parameter.

Fix: Use "runtime" instead of "immediate".

Result: The firewall role does not give an error.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Bug Fixes:
- Update firewall role to use the supported runtime parameter instead of the deprecated immediate option when configuring custom tangd ports.