### PR TITLE
docs(changelog): version 1.6.1 [citest_skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+[1.6.1] - 2026-05-07
+--------------------
+
+### Bug Fixes
+
+- fix: firewall - use runtime instead of deprecated immediate (#234)
+
+### Other Changes
+
+- ci: Bump actions/github-script from 8 to 9 (#235)
+
 [1.6.0] - 2026-04-28
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.6.1

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Document the 1.6.1 release in the changelog, including its key bug fix and CI dependency update.

Bug Fixes:
- Document a firewall bug fix switching from deprecated immediate mode to runtime mode.

CI:
- Document the CI workflow update to actions/github-script v9.

Documentation:
- Add changelog entry for version 1.6.1 and update associated release documentation.