### PR TITLE
fix: Prevent symlink following privilege escalation in nbde_server_tang module

### DIFF
--- a/library/nbde_server_tang.py
+++ b/library/nbde_server_tang.py
@@ -310,12 +310,20 @@ def set_file_ownership_and_perms(module, target):
         if not listing.endswith(".jwk"):
             continue
         fname = os.path.join(target, listing)
-        # Prevent symlink following attacks - skip symlinks
+        # Defense in depth - skip obvious symlinks
         if os.path.islink(fname):
             continue
-        # Use lchown to avoid following symlinks (defense in depth)
-        os.lchown(fname, uid, gid)
-        os.chmod(fname, 0o400)
+        # Atomically open with O_NOFOLLOW to prevent TOCTOU race
+        try:
+            fd = os.open(fname, os.O_RDONLY | os.O_NOFOLLOW)
+        except (OSError, IOError):
+            # ELOOP (symlink) or EINVAL - skip this file
+            continue
+        try:
+            os.fchown(fd, uid, gid)
+            os.fchmod(fd, 0o400)
+        finally:
+            os.close(fd)
 
 
 def run_module():

--- a/library/nbde_server_tang.py
+++ b/library/nbde_server_tang.py
@@ -310,7 +310,11 @@ def set_file_ownership_and_perms(module, target):
         if not listing.endswith(".jwk"):
             continue
         fname = os.path.join(target, listing)
-        os.chown(fname, uid, gid)
+        # Prevent symlink following attacks - skip symlinks
+        if os.path.islink(fname):
+            continue
+        # Use lchown to avoid following symlinks (defense in depth)
+        os.lchown(fname, uid, gid)
         os.chmod(fname, 0o400)
 
 

--- a/pytest_extra_requirements.txt
+++ b/pytest_extra_requirements.txt
@@ -4,4 +4,4 @@
 # If you need ansible then uncomment the following line:
 #-ransible_pytest_extra_requirements.txt
 # If you need mock then uncomment the following line:
-#mock ; python_version < "3.0"
+mock ; python_version < "3.0"

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/tests/unit/test_nbde_server_tang.py
+++ b/tests/unit/test_nbde_server_tang.py
@@ -11,6 +11,7 @@ __metaclass__ = type
 
 import errno
 import os
+import shutil
 import sys
 import tempfile
 import unittest
@@ -303,8 +304,6 @@ class TestIntegrationSymlinkProtection(unittest.TestCase):
 
     def tearDown(self):
         """Clean up test directory."""
-        import shutil
-
         shutil.rmtree(self.test_dir, ignore_errors=True)
 
     def test_real_symlink_is_skipped(self):

--- a/tests/unit/test_nbde_server_tang.py
+++ b/tests/unit/test_nbde_server_tang.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2024, Red Hat, Inc.
@@ -17,9 +16,9 @@ import tempfile
 import unittest
 
 try:
-    from unittest.mock import MagicMock, Mock, patch, call
+    from unittest.mock import MagicMock, Mock, patch
 except ImportError:
-    from mock import MagicMock, Mock, patch, call
+    from mock import MagicMock, Mock, patch
 
 # Mock Ansible imports before importing the module
 sys.modules["ansible"] = MagicMock()
@@ -75,12 +74,8 @@ class TestSymlinkProtection(unittest.TestCase):
 
         # Verify files were opened with O_NOFOLLOW
         self.assertEqual(mock_open.call_count, 2)
-        mock_open.assert_any_call(
-            "/test/keydir/key1.jwk", os.O_RDONLY | os.O_NOFOLLOW
-        )
-        mock_open.assert_any_call(
-            "/test/keydir/key2.jwk", os.O_RDONLY | os.O_NOFOLLOW
-        )
+        mock_open.assert_any_call("/test/keydir/key1.jwk", os.O_RDONLY | os.O_NOFOLLOW)
+        mock_open.assert_any_call("/test/keydir/key2.jwk", os.O_RDONLY | os.O_NOFOLLOW)
 
         # Verify ownership was changed
         self.assertEqual(mock_fchown.call_count, 2)
@@ -247,9 +242,7 @@ class TestSymlinkProtection(unittest.TestCase):
     @patch("nbde_server_tang.os.path.isdir")
     @patch("nbde_server_tang.get_dir_ownership")
     @patch("nbde_server_tang.os.listdir")
-    def test_non_jwk_files_ignored(
-        self, mock_listdir, mock_get_ownership, mock_isdir
-    ):
+    def test_non_jwk_files_ignored(self, mock_listdir, mock_get_ownership, mock_isdir):
         """Test that non-.jwk files are ignored."""
         mock_isdir.return_value = True
         mock_get_ownership.return_value = (self.uid, self.gid)
@@ -322,8 +315,8 @@ class TestIntegrationSymlinkProtection(unittest.TestCase):
             f.write('{"test": "key"}')
 
         # Create a symlink pointing outside the directory
-        target_file = tempfile.mktemp(prefix="target_")
-        with open(target_file, "w") as f:
+        with tempfile.NamedTemporaryFile(mode="w", prefix="target_", delete=False) as f:
+            target_file = f.name
             f.write("sensitive data")
         symlink_file = os.path.join(self.test_dir, "symlink.jwk")
         os.symlink(target_file, symlink_file)

--- a/tests/unit/test_nbde_server_tang.py
+++ b/tests/unit/test_nbde_server_tang.py
@@ -1,0 +1,352 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2024, Red Hat, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for nbde_server_tang module symlink protection."""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import errno
+import os
+import sys
+import tempfile
+import unittest
+
+try:
+    from unittest.mock import MagicMock, Mock, patch, call
+except ImportError:
+    from mock import MagicMock, Mock, patch, call
+
+# Mock Ansible imports before importing the module
+sys.modules["ansible"] = MagicMock()
+sys.modules["ansible.module_utils"] = MagicMock()
+sys.modules["ansible.module_utils.basic"] = MagicMock()
+sys.modules["ansible.module_utils._text"] = MagicMock()
+
+# Add library directory to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../library"))
+
+# pylint: disable=wrong-import-position
+import nbde_server_tang  # noqa: E402
+
+
+class TestSymlinkProtection(unittest.TestCase):
+    """Test symlink protection in set_file_ownership_and_perms."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.module = Mock()
+        self.module.check_mode = False
+        self.test_dir = "/test/keydir"
+        self.uid = 1000
+        self.gid = 1000
+
+    @patch("nbde_server_tang.os.path.isdir")
+    @patch("nbde_server_tang.get_dir_ownership")
+    @patch("nbde_server_tang.os.listdir")
+    @patch("nbde_server_tang.os.path.islink")
+    @patch("nbde_server_tang.os.open")
+    @patch("nbde_server_tang.os.fchown")
+    @patch("nbde_server_tang.os.fchmod")
+    @patch("nbde_server_tang.os.close")
+    def test_normal_file_ownership_change(
+        self,
+        mock_close,
+        mock_fchmod,
+        mock_fchown,
+        mock_open,
+        mock_islink,
+        mock_listdir,
+        mock_get_ownership,
+        mock_isdir,
+    ):
+        """Test that normal files have ownership and permissions changed."""
+        mock_isdir.return_value = True
+        mock_get_ownership.return_value = (self.uid, self.gid)
+        mock_listdir.return_value = ["key1.jwk", "key2.jwk"]
+        mock_islink.return_value = False
+        mock_open.return_value = 42  # File descriptor
+
+        nbde_server_tang.set_file_ownership_and_perms(self.module, self.test_dir)
+
+        # Verify files were opened with O_NOFOLLOW
+        self.assertEqual(mock_open.call_count, 2)
+        mock_open.assert_any_call(
+            "/test/keydir/key1.jwk", os.O_RDONLY | os.O_NOFOLLOW
+        )
+        mock_open.assert_any_call(
+            "/test/keydir/key2.jwk", os.O_RDONLY | os.O_NOFOLLOW
+        )
+
+        # Verify ownership was changed
+        self.assertEqual(mock_fchown.call_count, 2)
+        mock_fchown.assert_any_call(42, self.uid, self.gid)
+
+        # Verify permissions were set
+        self.assertEqual(mock_fchmod.call_count, 2)
+        mock_fchmod.assert_any_call(42, 0o400)
+
+        # Verify file descriptors were closed
+        self.assertEqual(mock_close.call_count, 2)
+        mock_close.assert_any_call(42)
+
+    @patch("nbde_server_tang.os.path.isdir")
+    @patch("nbde_server_tang.get_dir_ownership")
+    @patch("nbde_server_tang.os.listdir")
+    @patch("nbde_server_tang.os.path.islink")
+    @patch("nbde_server_tang.os.open")
+    @patch("nbde_server_tang.os.fchown")
+    @patch("nbde_server_tang.os.fchmod")
+    @patch("nbde_server_tang.os.close")
+    def test_symlink_skipped_by_islink_check(
+        self,
+        mock_close,
+        mock_fchmod,
+        mock_fchown,
+        mock_open,
+        mock_islink,
+        mock_listdir,
+        mock_get_ownership,
+        mock_isdir,
+    ):
+        """Test that symlinks detected by islink() are skipped."""
+        mock_isdir.return_value = True
+        mock_get_ownership.return_value = (self.uid, self.gid)
+        mock_listdir.return_value = ["symlink.jwk", "normal.jwk"]
+        # First file is a symlink, second is normal
+        mock_islink.side_effect = [True, False]
+        mock_open.return_value = 42
+
+        nbde_server_tang.set_file_ownership_and_perms(self.module, self.test_dir)
+
+        # Verify only one file was opened (symlink was skipped)
+        self.assertEqual(mock_open.call_count, 1)
+        mock_open.assert_called_once_with(
+            "/test/keydir/normal.jwk", os.O_RDONLY | os.O_NOFOLLOW
+        )
+
+        # Verify ownership/permissions only set once
+        self.assertEqual(mock_fchown.call_count, 1)
+        self.assertEqual(mock_fchmod.call_count, 1)
+        self.assertEqual(mock_close.call_count, 1)
+
+    @patch("nbde_server_tang.os.path.isdir")
+    @patch("nbde_server_tang.get_dir_ownership")
+    @patch("nbde_server_tang.os.listdir")
+    @patch("nbde_server_tang.os.path.islink")
+    @patch("nbde_server_tang.os.open")
+    @patch("nbde_server_tang.os.fchown")
+    @patch("nbde_server_tang.os.fchmod")
+    @patch("nbde_server_tang.os.close")
+    def test_symlink_caught_by_o_nofollow(
+        self,
+        mock_close,
+        mock_fchmod,
+        mock_fchown,
+        mock_open,
+        mock_islink,
+        mock_listdir,
+        mock_get_ownership,
+        mock_isdir,
+    ):
+        """Test that symlinks caught by O_NOFOLLOW are handled safely."""
+        mock_isdir.return_value = True
+        mock_get_ownership.return_value = (self.uid, self.gid)
+        mock_listdir.return_value = ["racecondition.jwk"]
+        # islink returns False (TOCTOU race), but O_NOFOLLOW catches it
+        mock_islink.return_value = False
+        # Simulate ELOOP error from O_NOFOLLOW
+        mock_open.side_effect = OSError(errno.ELOOP, "Too many symbolic links")
+
+        nbde_server_tang.set_file_ownership_and_perms(self.module, self.test_dir)
+
+        # Verify open was attempted
+        self.assertEqual(mock_open.call_count, 1)
+
+        # Verify ownership/permissions were NOT set (exception caught)
+        mock_fchown.assert_not_called()
+        mock_fchmod.assert_not_called()
+        mock_close.assert_not_called()
+
+    @patch("nbde_server_tang.os.path.isdir")
+    @patch("nbde_server_tang.get_dir_ownership")
+    @patch("nbde_server_tang.os.listdir")
+    @patch("nbde_server_tang.os.path.islink")
+    @patch("nbde_server_tang.os.open")
+    @patch("nbde_server_tang.os.fchown")
+    @patch("nbde_server_tang.os.fchmod")
+    @patch("nbde_server_tang.os.close")
+    def test_ioerror_handled_gracefully(
+        self,
+        mock_close,
+        mock_fchmod,
+        mock_fchown,
+        mock_open,
+        mock_islink,
+        mock_listdir,
+        mock_get_ownership,
+        mock_isdir,
+    ):
+        """Test that IOError exceptions are handled gracefully."""
+        mock_isdir.return_value = True
+        mock_get_ownership.return_value = (self.uid, self.gid)
+        mock_listdir.return_value = ["error.jwk"]
+        mock_islink.return_value = False
+        # Simulate IOError (Python 2 compatibility)
+        mock_open.side_effect = IOError(errno.EACCES, "Permission denied")
+
+        nbde_server_tang.set_file_ownership_and_perms(self.module, self.test_dir)
+
+        # Verify open was attempted
+        self.assertEqual(mock_open.call_count, 1)
+
+        # Verify ownership/permissions were NOT set
+        mock_fchown.assert_not_called()
+        mock_fchmod.assert_not_called()
+        mock_close.assert_not_called()
+
+    @patch("nbde_server_tang.os.path.isdir")
+    @patch("nbde_server_tang.get_dir_ownership")
+    @patch("nbde_server_tang.os.listdir")
+    @patch("nbde_server_tang.os.path.islink")
+    @patch("nbde_server_tang.os.open")
+    @patch("nbde_server_tang.os.fchown")
+    @patch("nbde_server_tang.os.fchmod")
+    @patch("nbde_server_tang.os.close")
+    def test_fd_closed_even_on_fchown_error(
+        self,
+        mock_close,
+        mock_fchmod,
+        mock_fchown,
+        mock_open,
+        mock_islink,
+        mock_listdir,
+        mock_get_ownership,
+        mock_isdir,
+    ):
+        """Test that file descriptor is closed even if fchown fails."""
+        mock_isdir.return_value = True
+        mock_get_ownership.return_value = (self.uid, self.gid)
+        mock_listdir.return_value = ["key.jwk"]
+        mock_islink.return_value = False
+        mock_open.return_value = 42
+        # Simulate fchown failure
+        mock_fchown.side_effect = OSError(errno.EPERM, "Operation not permitted")
+
+        # Should raise exception but still close fd
+        with self.assertRaises(OSError):
+            nbde_server_tang.set_file_ownership_and_perms(self.module, self.test_dir)
+
+        # Verify fd was closed despite error
+        mock_close.assert_called_once_with(42)
+
+    @patch("nbde_server_tang.os.path.isdir")
+    @patch("nbde_server_tang.get_dir_ownership")
+    @patch("nbde_server_tang.os.listdir")
+    def test_non_jwk_files_ignored(
+        self, mock_listdir, mock_get_ownership, mock_isdir
+    ):
+        """Test that non-.jwk files are ignored."""
+        mock_isdir.return_value = True
+        mock_get_ownership.return_value = (self.uid, self.gid)
+        mock_listdir.return_value = [
+            "key.jwk",
+            "readme.txt",
+            ".hidden",
+            "config.json",
+        ]
+
+        with patch("nbde_server_tang.os.path.islink") as mock_islink:
+            mock_islink.return_value = False
+            with patch("nbde_server_tang.os.open") as mock_open:
+                mock_open.return_value = 42
+                with patch("nbde_server_tang.os.fchown"):
+                    with patch("nbde_server_tang.os.fchmod"):
+                        with patch("nbde_server_tang.os.close"):
+                            nbde_server_tang.set_file_ownership_and_perms(
+                                self.module, self.test_dir
+                            )
+
+                            # Only .jwk file should be processed
+                            self.assertEqual(mock_open.call_count, 1)
+                            mock_open.assert_called_once_with(
+                                "/test/keydir/key.jwk", os.O_RDONLY | os.O_NOFOLLOW
+                            )
+
+    @patch("nbde_server_tang.os.path.isdir")
+    def test_check_mode_skips_operation(self, mock_isdir):
+        """Test that check mode skips all operations."""
+        self.module.check_mode = True
+        mock_isdir.return_value = True
+
+        with patch("nbde_server_tang.get_dir_ownership") as mock_get_ownership:
+            nbde_server_tang.set_file_ownership_and_perms(self.module, self.test_dir)
+            # Should return early, not call get_dir_ownership
+            mock_get_ownership.assert_not_called()
+
+    @patch("nbde_server_tang.os.path.isdir")
+    def test_non_directory_skips_operation(self, mock_isdir):
+        """Test that non-directory target skips all operations."""
+        mock_isdir.return_value = False
+
+        with patch("nbde_server_tang.get_dir_ownership") as mock_get_ownership:
+            nbde_server_tang.set_file_ownership_and_perms(self.module, self.test_dir)
+            # Should return early
+            mock_get_ownership.assert_not_called()
+
+
+class TestIntegrationSymlinkProtection(unittest.TestCase):
+    """Integration tests with real filesystem operations."""
+
+    def setUp(self):
+        """Create temporary directory for testing."""
+        self.test_dir = tempfile.mkdtemp(prefix="nbde_test_")
+        self.module = Mock()
+        self.module.check_mode = False
+
+    def tearDown(self):
+        """Clean up test directory."""
+        import shutil
+
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def test_real_symlink_is_skipped(self):
+        """Integration test: Real symlinks are skipped."""
+        # Create a real key file
+        key_file = os.path.join(self.test_dir, "real.jwk")
+        with open(key_file, "w") as f:
+            f.write('{"test": "key"}')
+
+        # Create a symlink pointing outside the directory
+        target_file = tempfile.mktemp(prefix="target_")
+        with open(target_file, "w") as f:
+            f.write("sensitive data")
+        symlink_file = os.path.join(self.test_dir, "symlink.jwk")
+        os.symlink(target_file, symlink_file)
+
+        try:
+            # Get original ownership of target
+            target_stat_before = os.stat(target_file)
+
+            # Run the function
+            nbde_server_tang.set_file_ownership_and_perms(self.module, self.test_dir)
+
+            # Verify target ownership was NOT changed
+            target_stat_after = os.stat(target_file)
+            self.assertEqual(target_stat_before.st_uid, target_stat_after.st_uid)
+            self.assertEqual(target_stat_before.st_gid, target_stat_after.st_gid)
+
+            # Verify real key file was processed
+            key_stat = os.stat(key_file)
+            self.assertEqual(key_stat.st_mode & 0o777, 0o400)
+
+        finally:
+            os.unlink(target_file)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Enhancement:** Added symlink protection to prevent privilege escalation vulnerability in the `set_file_ownership_and_perms()` function.

**Reason:** The module was using `os.chown()` which follows symlinks. An unprivileged local user could pre-stage symlinks in tang keydir pointing to sensitive files. When the module runs as root, it would follow the symlinks and change ownership of arbitrary files to the tang user, enabling privilege escalation.

**Result:** The module now:
1. Explicitly checks and skips symlinks before processing files
2. Uses `os.lchown()` instead of `os.chown()` for defense in depth (lchown does not follow symlinks)

This prevents the symlink-following attack vector while maintaining the intended functionality of setting ownership and permissions on legitimate tang key files.

**Security Impact:** Prevents local privilege escalation attack where unprivileged users could manipulate file ownership through symlink attacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened ownership and permission updates to safely skip symbolic links (including `.jwk` symlink handling) and avoid following them, preventing unintended changes to link targets.

* **Tests**
  * Added unit and integration coverage for symlink protection, error handling, check-mode behavior, and non-`.jwk`/non-directory edge cases.

* **Chores**
  * Enabled an additional pytest requirement for older Python versions and added a minimal unit test package initializer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->